### PR TITLE
Feature output all possible outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ versions prior to 1.0.0 any release might break compatability. To alleviate this
 the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some
 breaking changes may slip beneath notice.
 
+## Version 0.6.5
+* "output_keys" and "output_plot" in the input file can now be "all", "nothing" or a list of entries for custom outputs of the CSV file and lineplot (backwards compatibility is given)
+* output_values() of all components was changed to not only return the available channels, but also the corresponding media
+* restructured "run_simulation()" for better readability
+
 ## Version 0.6.4
 * Generalise implementation of gas boiler to that of a fuel boiler
   * Although this implicates the use of a chemical fuel to generate heat, the current implementation works with any kind of input including electricity

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -38,21 +38,8 @@ function run_simulation(project_config::Dict{AbstractString,Any})
         step_order = calculate_order_of_operations(components)
     end
 
-    time_step = 900
-    if "time_step_seconds" in keys(project_config["simulation_parameters"])
-        time_step = UInt(project_config["simulation_parameters"]["time_step_seconds"])
-    end
-
-    start_timestamp = 0
-    if "start" in keys(project_config["simulation_parameters"])
-        start_timestamp = Integer(project_config["simulation_parameters"]["start"])
-    end
-
-    end_timestamp = 900
-    if "end" in keys(project_config["simulation_parameters"])
-        end_timestamp = Integer(project_config["simulation_parameters"]["end"])
-    end
-
+    # get time steps from input file
+    time_step, start_timestamp, end_timestamp = get_timesteps(project_config["simulation_parameters"])  
     nr_of_steps = UInt(max(1, (end_timestamp - start_timestamp) / time_step))
 
     parameters = Dict{String,Any}(

--- a/src/energy_systems/base.jl
+++ b/src/energy_systems/base.jl
@@ -500,13 +500,16 @@ end
 """
     output_values(unit)
 
-Specify which outputs a component can provide.
+Specify which data outputs a component can provide, including the medium of each output.
+Output at this point means data output in every timestep. This can include the energy on 
+the input- and output interfaces of a unit or its current state (like "LOAD").
 
-For the special values "IN" and "OUT" a medium category is required for fetching the actual
-value, while this method only specifies that there is an input or output.
+This methods provides the actual output type (like "IN" or "OUT") and the corresponding
+media of the data outputs. A medium is only needed for inputs and outputs, not for states.
 """
 function output_values(unit::Component)::Vector{String}
-    return ["IN", "OUT"]
+    return []  # base implementation returns an empty output vector as the output values 
+               # have to be specified in every component.
 end
 
 """

--- a/src/energy_systems/connections/grid_connection.jl
+++ b/src/energy_systems/connections/grid_connection.jl
@@ -81,7 +81,15 @@ function process(unit::GridConnection, parameters::Dict{String,Any})
 end
 
 function output_values(unit::GridConnection)::Vector{String}
-    return ["IN", "OUT", "Draw sum", "Load sum"]
+    if unit.sys_function == sf_bounded_source
+        return [string(unit.medium)*" OUT",
+                "Draw_sum",
+                "Load_sum"]
+    elseif unit.sys_function == sf_bounded_sink
+        return [string(unit.medium)*" IN",
+                "Draw_sum",
+                "Load_sum"]
+    end
 end
 
 function output_value(unit::GridConnection, key::OutputKey)::Float64
@@ -89,9 +97,9 @@ function output_value(unit::GridConnection, key::OutputKey)::Float64
         return calculate_energy_flow(unit.input_interfaces[key.medium])
     elseif key.value_key == "OUT"
         return calculate_energy_flow(unit.output_interfaces[key.medium])
-    elseif key.value_key == "Draw sum"
+    elseif key.value_key == "Draw_sum"
         return unit.draw_sum
-    elseif key.value_key == "Load sum"
+    elseif key.value_key == "Load_sum"
         return unit.load_sum
     end
     throw(KeyError(key.value_key))

--- a/src/energy_systems/electric_producers/pv_plant.jl
+++ b/src/energy_systems/electric_producers/pv_plant.jl
@@ -48,7 +48,8 @@ mutable struct PVPlant <: Component
 end
 
 function output_values(unit::PVPlant)::Vector{String}
-    return ["OUT", "Supply"]
+    return [string(unit.m_el_out)*" OUT",
+            "Supply"]
 end
 
 function output_value(unit::PVPlant, key::OutputKey)::Float64

--- a/src/energy_systems/general/bounded_sink.jl
+++ b/src/energy_systems/general/bounded_sink.jl
@@ -59,7 +59,14 @@ mutable struct BoundedSink <: Component
 end
 
 function output_values(unit::BoundedSink)::Vector{String}
-    return ["IN", "Max_Energy"]
+    if unit.temperature_profile === nothing && unit.static_temperature === nothing
+        return [string(unit.medium)*" IN",
+                "Max_Energy"]
+    else
+        return [string(unit.medium)*" IN",
+                "Max_Energy",
+                "Temperature"]
+    end
 end
 
 function output_value(unit::BoundedSink, key::OutputKey)::Float64
@@ -67,6 +74,8 @@ function output_value(unit::BoundedSink, key::OutputKey)::Float64
         return calculate_energy_flow(unit.input_interfaces[key.medium])
     elseif key.value_key == "Max_Energy"
         return unit.max_energy
+    elseif key.value_key == "Temperature"
+        return unit.temperature
     end
     throw(KeyError(key.value_key))
 end

--- a/src/energy_systems/general/bounded_supply.jl
+++ b/src/energy_systems/general/bounded_supply.jl
@@ -59,7 +59,14 @@ mutable struct BoundedSupply <: Component
 end
 
 function output_values(unit::BoundedSupply)::Vector{String}
-    return ["OUT", "Max_Energy", "Temperature"]
+    if unit.temperature_profile === nothing && unit.static_temperature === nothing
+        return [string(unit.medium)*" OUT",
+                "Max_Energy"]
+    else
+        return [string(unit.medium)*" OUT",
+                "Max_Energy",
+                "Temperature"]
+    end
 end
 
 function output_value(unit::BoundedSupply, key::OutputKey)::Float64

--- a/src/energy_systems/general/fixed_sink.jl
+++ b/src/energy_systems/general/fixed_sink.jl
@@ -62,7 +62,14 @@ mutable struct FixedSink <: Component
 end
 
 function output_values(unit::FixedSink)::Vector{String}
-    return ["IN", "Load", "Temperature"]
+    if unit.temperature_profile === nothing && unit.static_temperature === nothing
+        return [string(unit.medium)*" IN",
+                "Load"]
+    else
+        return [string(unit.medium)*" IN",
+                "Load",
+                "Temperature"]
+    end
 end
 
 function output_value(unit::FixedSink, key::OutputKey)::Float64

--- a/src/energy_systems/general/fixed_supply.jl
+++ b/src/energy_systems/general/fixed_supply.jl
@@ -62,7 +62,14 @@ mutable struct FixedSupply <: Component
 end
 
 function output_values(unit::FixedSupply)::Vector{String}
-    return ["OUT", "Supply", "Temperature"]
+    if unit.temperature_profile === nothing && unit.static_temperature === nothing
+        return [string(unit.medium)*" OUT",
+                "Supply"]
+    else
+        return [string(unit.medium)*" OUT",
+                "Supply",
+                "Temperature"]
+    end
 end
 
 function output_value(unit::FixedSupply, key::OutputKey)::Float64

--- a/src/energy_systems/general/storage.jl
+++ b/src/energy_systems/general/storage.jl
@@ -109,7 +109,11 @@ function load(unit::Storage, parameters::Dict{String,Any})
 end
 
 function output_values(unit::Storage)::Vector{String}
-    return ["IN", "OUT", "Load", "Load%", "Capacity"]
+    return [string(unit.medium)*" IN",
+            string(unit.medium)*" OUT",
+            "Load",
+            "Load%",
+            "Capacity"]
 end
 
 function output_value(unit::Storage, key::OutputKey)::Float64

--- a/src/energy_systems/heat_producers/heat_pump.jl
+++ b/src/energy_systems/heat_producers/heat_pump.jl
@@ -75,7 +75,10 @@ function control(
 end
 
 function output_values(unit::HeatPump)::Vector{String}
-    return ["IN", "OUT", "COP"]
+    return [string(unit.m_el_in)*" IN", 
+            string(unit.m_heat_in)*" IN",
+            string(unit.m_heat_out)*" OUT",
+            "COP"]
 end
 
 function output_value(unit::HeatPump, key::OutputKey)::Float64

--- a/src/energy_systems/heat_sources/geothermal_heat_collectors.jl
+++ b/src/energy_systems/heat_sources/geothermal_heat_collectors.jl
@@ -286,7 +286,13 @@ function balance_on(
 end
 
 function output_values(unit::GeothermalHeatCollector)::Vector{String}
-    return ["IN", "OUT", "TEMPERATURE_#NodeNum"]
+    temp_vect = []
+    append!(temp_vect, string(unit.m_heat_in)*" IN")
+    append!(temp_vect, string(unit.m_heat_out)*" OUT")
+    for n in range(length(unit.temperature_field))
+        append!(temp_vect, "TEMPERATURE_"*string(n))
+    end
+    return temp_vect
 end
 
 function output_value(unit::GeothermalHeatCollector, key::OutputKey)::Float64

--- a/src/energy_systems/heat_sources/geothermal_probes.jl
+++ b/src/energy_systems/heat_sources/geothermal_probes.jl
@@ -286,7 +286,13 @@ function balance_on(
 end
 
 function output_values(unit::GeothermalProbes)::Vector{String}
-    return ["IN", "OUT", "TEMPERATURE_#NodeNum"]
+    temp_vect = []
+    append!(temp_vect, string(unit.m_heat_in)*" IN")
+    append!(temp_vect, string(unit.m_heat_out)*" OUT")
+    for n in range(length(unit.temperature_field))
+        append!(temp_vect, "TEMPERATURE_"*string(n))
+    end
+    return temp_vect
 end
 
 function output_value(unit::GeothermalProbes, key::OutputKey)::Float64

--- a/src/energy_systems/storage/battery.jl
+++ b/src/energy_systems/storage/battery.jl
@@ -115,7 +115,11 @@ function load(unit::Battery, parameters::Dict{String,Any})
 end
 
 function output_values(unit::Battery)::Vector{String}
-    return ["IN", "OUT", "Load", "Load%", "Capacity"]
+    return [string(unit.medium)*" IN",
+            string(unit.medium)*" OUT",
+            "Load",
+            "Load%",
+            "Capacity"]
 end
 
 function output_value(unit::Battery, key::OutputKey)::Float64

--- a/src/energy_systems/storage/buffer_tank.jl
+++ b/src/energy_systems/storage/buffer_tank.jl
@@ -148,7 +148,11 @@ function load(unit::BufferTank, parameters::Dict{String,Any})
 end
 
 function output_values(unit::BufferTank)::Vector{String}
-    return ["IN", "OUT", "Load", "Load%", "Capacity"]
+    return [string(unit.medium)*" IN",
+            string(unit.medium)*" OUT",
+            "Load",
+            "Load%",
+            "Capacity"]
 end
 
 function output_value(unit::BufferTank, key::OutputKey)::Float64

--- a/src/energy_systems/storage/seasonal_thermal_storage.jl
+++ b/src/energy_systems/storage/seasonal_thermal_storage.jl
@@ -151,7 +151,11 @@ function load(unit::SeasonalThermalStorage, parameters::Dict{String,Any})
 end
 
 function output_values(unit::SeasonalThermalStorage)::Vector{String}
-    return ["IN", "OUT", "Load", "Load%", "Capacity"]
+    return [string(unit.m_heat_in)*" IN",
+            string(unit.m_heat_out)*" OUT",
+            "Load",
+            "Load%",
+            "Capacity"]
 end
 
 function output_value(unit::SeasonalThermalStorage, key::OutputKey)::Float64

--- a/src/file_output.jl
+++ b/src/file_output.jl
@@ -144,29 +144,44 @@ create a line plot with data and label. user_input is dict from input file
 function create_profile_line_plots(
     outputs_plot_data::Matrix{Float64},
     outputs_plot_keys::Vector{EnergySystems.OutputKey},
-    user_input::Dict{String,Any}
+    plot_all::Bool,
+    user_input::Union{Nothing,Dict{String,Any}}
 )
 
-    # set Axis, unit and scale factor
-    axis = String[]
-    unit = String[]
-    scale_fact = Float64[]
-    for plot in user_input
-        push!(axis, string(plot[2]["axis"]))
-        push!(unit, string(plot[2]["unit"]))
-        push!(scale_fact, plot[2]["scale_factor"])
-    end
-
-    # create legend entries
-    labels = String[]
-    n = 1
-    for outkey in outputs_plot_keys
-        if outkey.medium === nothing
-            push!(labels, string("$(outkey.unit.uac) $(outkey.value_key) [$(unit[n])] ($(axis[n]))"))
-        else
-            push!(labels, string("$(outkey.unit.uac) $(outkey.medium) $(outkey.value_key) [$(unit[n])] ($(axis[n]))"))
+    # set Axis, unit and scale factor if given
+    if !plot_all  # plot only defined outputs
+        axis = String[]
+        unit = String[]
+        scale_fact = Float64[]
+        for plot in user_input
+            push!(axis, string(plot[2]["axis"]))
+            push!(unit, string(plot[2]["unit"]))
+            push!(scale_fact, plot[2]["scale_factor"])
         end
-        n += 1
+   
+        # create legend entries
+        labels = String[]
+        n = 1
+        for outkey in outputs_plot_keys
+            if outkey.medium === nothing
+                push!(labels, string("$(outkey.unit.uac) $(outkey.value_key) [$(unit[n])] ($(axis[n]))"))
+            else
+                push!(labels, string("$(outkey.unit.uac) $(outkey.medium) $(outkey.value_key) [$(unit[n])] ($(axis[n]))"))
+            end
+            n += 1
+        end
+    else # plot all outputs. Here no units or scaling factors are available.
+         # create legend entries if no information is given
+         labels = String[]
+         n = 1
+         for outkey in outputs_plot_keys
+             if outkey.medium === nothing
+                 push!(labels, string("$(outkey.unit.uac) $(outkey.value_key)"))
+             else
+                 push!(labels, string("$(outkey.unit.uac) $(outkey.medium) $(outkey.value_key)"))
+             end
+             n += 1
+         end
     end
 
     # create plot
@@ -174,11 +189,15 @@ function create_profile_line_plots(
     y = outputs_plot_data[:, 2:end]
     traces = GenericTrace[]
     for i in axes(y, 2)
-        trace = scatter(x=x / 60 / 60, y=scale_fact[i] * y[:, i], mode="lines", name=labels[i])
-        if axis[i] == "right"
-            trace.yaxis = "y2"
-        else  # default is left axis
-            trace.yaxis = "y1"
+        if !plot_all
+            trace = scatter(x=x / 60 / 60, y=scale_fact[i] * y[:, i], mode="lines", name=labels[i])
+            if axis[i] == "right"
+                trace.yaxis = "y2"
+            else  # default is left axis
+                trace.yaxis = "y1"
+            end
+        else
+            trace = scatter(x=x / 60 / 60, y=y[:, i], mode="lines", name=labels[i])
         end
         push!(traces, trace)
     end

--- a/src/file_output.jl
+++ b/src/file_output.jl
@@ -1,5 +1,162 @@
 # this file contains functionality for writing output of the simulation to files.
 
+
+"""
+get_output_keys(config[io_settings], components)
+
+This function determines both for the lineplot and the csv output if
+they should be created:
+    - if not, "nothing" will be returned as key list
+    - if yes, the key lists of the outputs will be returned, either containing
+        - all possible keys if this is requested in the input file or
+        - only the requested keys as requested in the input file
+"""
+function get_output_keys(io_settings::Dict{String, Any}, 
+                         components::Grouping
+                         )::Tuple{Union{Nothing, Vector{EnergySystems.OutputKey}}, Union{Nothing, Vector{EnergySystems.OutputKey}}}
+    # determine if lineplot and csv should be created
+    do_plot_all_outputs = false
+    do_create_plot = false
+    if haskey(io_settings, "output_plot")
+        do_create_plot = true  # if the key exists, set do_create_plot to true by default
+        if io_settings["output_plot"] == "all"
+            do_plot_all_outputs = true
+        elseif io_settings["output_plot"] == "nothing"
+            do_create_plot = false
+        end
+    end
+
+    do_write_all_CSV_outputs = false
+    do_write_CSV = false
+    if haskey(io_settings, "output_keys")
+        do_write_CSV = true  # if the key exists, set do_create_plot to true by default
+        if io_settings["output_keys"] == "all"
+            do_write_all_CSV_outputs = true
+        elseif io_settings["output_keys"] == "nothing"
+            do_write_CSV = false
+        end
+    end
+
+     # collect all possible outputs of all units if needed
+    if do_plot_all_outputs || do_write_all_CSV_outputs
+        all_output_keys = Vector{EnergySystems.OutputKey}()
+        for unit in components
+            temp_dict = Dict{String, Any}(unit[2].uac => output_values(unit[2]))
+            append!(all_output_keys, output_keys(components, temp_dict))
+        end
+    end
+
+    # collect output keys for lineplot and csv output
+    if do_create_plot  # line plot
+        output_keys_lineplot = do_plot_all_outputs ? all_output_keys : Vector{EnergySystems.OutputKey}()
+        # Collect output keys if not plotting all outputs
+        if !do_plot_all_outputs
+            for plot in io_settings["output_plot"]
+                key = plot[2]["key"]
+                append!(output_keys_lineplot, output_keys(components, key))
+            end
+        end
+    else
+        output_keys_lineplot = nothing
+    end
+
+    if do_write_CSV  # csv export
+        if do_write_all_CSV_outputs # gather all outputs
+            output_keys_to_csv = all_output_keys
+        else  # get only requested output keys from input file for CSV-export
+            output_keys_to_csv = output_keys(components, io_settings["output_keys"])
+        end
+    else
+        output_keys_to_csv = nothing
+    end
+
+    return output_keys_lineplot, output_keys_to_csv
+end
+
+"""
+get_interface_information(components)
+
+
+Function to gather information for the sankey diagram.
+Determines 
+- the total number of present system interfaces [int]
+- the corresponding medium in each interface [medium]
+- the source component of each interface and [unit]
+- the target component of each interface [unit]
+
+The information is returned as single vectors with the indicees matching together.
+"""
+function get_interface_information(components::Grouping)::Tuple{Int64,Vector{Any},Vector{Any},Vector{Any}} 
+    nr_of_interfaces = 0
+    medium_of_interfaces = []
+    output_sourcenames_sankey = []
+    output_targetnames_sankey = []
+    for each_component in components
+        for each_outputinterface in each_component[2].output_interfaces
+            medium = nothing  # reset medium
+            if isa(each_outputinterface, Pair) # some output_interfaces are wrapped in a Touple
+                medium = each_outputinterface[1] # then, the medium is stored separately
+                each_outputinterface = each_outputinterface[2]
+            end
+
+            if isdefined(each_outputinterface, :target)
+                # count interface
+                nr_of_interfaces += 1
+
+                #get name of source and sink
+                push!(output_sourcenames_sankey, each_outputinterface.source.uac)
+                push!(output_targetnames_sankey, each_outputinterface.target.uac)
+
+                # get name of medium
+                if isdefined(each_outputinterface.target, :medium)
+                    push!(medium_of_interfaces, each_outputinterface.target.medium)
+                elseif isdefined(each_outputinterface.source, :medium)
+                    push!(medium_of_interfaces, each_outputinterface.source.medium)
+                elseif !(medium === nothing)
+                    push!(medium_of_interfaces, medium)
+                else
+                    println("Warning: The name of the medium was not detected. This may lead to wrong colouring in Sankey plot.")
+                end
+            end
+        end
+    end
+    println(
+        length(medium_of_interfaces) !== nr_of_interfaces
+        ? "Warning: error in extracting information from input file for sankey plot."
+        : ""
+    )
+
+    return nr_of_interfaces, medium_of_interfaces, output_sourcenames_sankey, output_targetnames_sankey
+end
+
+"""
+collect_interface_energies(components, nr_of_interfaces)
+
+Collects and returns the energy that was transportet through every interface.
+If the balance of an interface was not zero, the actual energy that was flowing
+is written to the outputs.
+Attention: This can lead to overfilling of demands which is currenlty not visible
+in the sankey diagram!
+"""
+function collect_interface_energies(components::Grouping, nr_of_interfaces::Int)
+    n = 1
+    energies = zeros(Float64, nr_of_interfaces)
+    for each_component in components
+        for each_outputinterface in each_component[2].output_interfaces
+            if isa(each_outputinterface, Pair) # some output_interfaces are wrapped in a Touple
+                if isdefined(each_outputinterface[2], :target)
+                    energies[n] = calculate_energy_flow(each_outputinterface[2])  
+                    n += 1
+                end
+            elseif isdefined(each_outputinterface, :target)
+                energies[n] = calculate_energy_flow(each_outputinterface) 
+                n += 1
+            end
+        end
+    end
+    return energies
+end    
+
 """
 output_keys(from_config)
 
@@ -144,16 +301,27 @@ create a line plot with data and label. user_input is dict from input file
 function create_profile_line_plots(
     outputs_plot_data::Matrix{Float64},
     outputs_plot_keys::Vector{EnergySystems.OutputKey},
-    plot_all::Bool,
-    user_input::Union{Nothing,Dict{String,Any}}
+    project_config::Dict{AbstractString, Any}
 )
-
+    plot_all = project_config["io_settings"]["output_plot"] == "all"
+    
     # set Axis, unit and scale factor if given
-    if !plot_all  # plot only defined outputs
+    if plot_all  # plot all outputs. Here no units or scaling factors are available.
+        labels = String[]
+        n = 1
+        for outkey in outputs_plot_keys
+            if outkey.medium === nothing
+                push!(labels, string("$(outkey.unit.uac) $(outkey.value_key)"))
+            else
+                push!(labels, string("$(outkey.unit.uac) $(outkey.medium) $(outkey.value_key)"))
+            end
+            n += 1
+        end
+    else # plot only defined outputs. Here units and scaling factors are available.
         axis = String[]
         unit = String[]
         scale_fact = Float64[]
-        for plot in user_input
+        for plot in project_config["io_settings"]["output_plot"]
             push!(axis, string(plot[2]["axis"]))
             push!(unit, string(plot[2]["unit"]))
             push!(scale_fact, plot[2]["scale_factor"])
@@ -170,18 +338,6 @@ function create_profile_line_plots(
             end
             n += 1
         end
-    else # plot all outputs. Here no units or scaling factors are available.
-         # create legend entries if no information is given
-         labels = String[]
-         n = 1
-         for outkey in outputs_plot_keys
-             if outkey.medium === nothing
-                 push!(labels, string("$(outkey.unit.uac) $(outkey.value_key)"))
-             else
-                 push!(labels, string("$(outkey.unit.uac) $(outkey.medium) $(outkey.value_key)"))
-             end
-             n += 1
-         end
     end
 
     # create plot
@@ -189,15 +345,15 @@ function create_profile_line_plots(
     y = outputs_plot_data[:, 2:end]
     traces = GenericTrace[]
     for i in axes(y, 2)
-        if !plot_all
+        if plot_all
+            trace = scatter(x=x / 60 / 60, y=y[:, i], mode="lines", name=labels[i])            
+        else
             trace = scatter(x=x / 60 / 60, y=scale_fact[i] * y[:, i], mode="lines", name=labels[i])
             if axis[i] == "right"
                 trace.yaxis = "y2"
             else  # default is left axis
                 trace.yaxis = "y1"
             end
-        else
-            trace = scatter(x=x / 60 / 60, y=y[:, i], mode="lines", name=labels[i])
         end
         push!(traces, trace)
     end

--- a/src/project_loading.jl
+++ b/src/project_loading.jl
@@ -743,3 +743,32 @@ function reorder_storage_loading(simulation_order, components, components_by_fun
         end
     end
 end
+
+"""
+get_timesteps(simulation_parameters)
+
+Function to read in the time step information from the input file.
+If no information is given in the input file, the following defaults 
+will be set:
+time_step = 900 s
+start_timestamp = 0 s
+end_timestamp = 900 s
+"""
+function get_timesteps(simulation_parameters::Dict{String, Any})
+    time_step = 900
+    if "time_step_seconds" in keys(simulation_parameters)
+        time_step = UInt(simulation_parameters["time_step_seconds"])
+    end
+
+    start_timestamp = 0
+    if "start" in keys(simulation_parameters)
+        start_timestamp = Integer(simulation_parameters["start"])
+    end
+
+    end_timestamp = 900
+    if "end" in keys(simulation_parameters)
+        end_timestamp = Integer(simulation_parameters["end"])
+    end
+
+    return time_step, start_timestamp, end_timestamp
+end


### PR DESCRIPTION
- "output_keys" and "output_plot" in the input file can now be "all", "nothing" or a list of entries as before for custom outputs of CSV and lineplot
- output_values() of all components was changed to not only return the available channels, but also the corresponding media
- restructured parts of "Resie.jl" for better readability (could probabely be further improved...)
 
Minor version bump needs to be done (backwards compatibility with old input files is given).