### PR TITLE
Apply auto-format to files of tests, heat pump and efficiency

### DIFF
--- a/src/energy_systems/base.jl
+++ b/src/energy_systems/base.jl
@@ -21,17 +21,17 @@ to the simulation as a whole as well as provide functionality on groups of compo
 module EnergySystems
 
 export check_balances, Component, each, Grouping, link_output_with, perform_steps,
-    output_values, output_value, StepInstruction, StepInstructions, calculate_energy_flow,
-    highest, default, plot_optional_figures
+       output_values, output_value, StepInstruction, StepInstructions, calculate_energy_flow,
+       highest, default, plot_optional_figures
 
 using ..Profiles
 
 """
 Convenience function to get the value of a key from a config dict using a default value.
 """
-default(config::Dict{String,Any}, name::String, default_val::Any)::Any =
-    return name in keys(config) ? config[name] : default_val
-
+default(config::Dict{String,Any}, name::String, default_val::Any)::Any = return name in keys(config) ?
+                                                                                config[name] :
+                                                                                default_val
 
 """
 The number of hours per time step, used by various utility functions.
@@ -65,7 +65,6 @@ function wh_to_watts(wh::Float64)
     return wh / HOURS_PER_TIME_STEP
 end
 
-
 """
 Categories that each represent a physical medium in conjunction with additional attributes,
 such as temperature or voltage. These attributes are not necessarily unchanging, but are
@@ -84,28 +83,27 @@ The names are structured in a composite of segments. For example, these are:
     4. 230v: Additional attributes of nominal value or ranges numbered through
 """
 medium_categories = Set{Symbol}([
-    # electricity
-    :m_e_ac_230v,
+                                 # electricity
+                                 :m_e_ac_230v,
 
-    # chemicals - gasses
-    :m_c_g_natgas,
-    :m_c_g_h2,
-    :m_c_g_o2,
+                                 # chemicals - gasses
+                                 :m_c_g_natgas,
+                                 :m_c_g_h2,
+                                 :m_c_g_o2,
 
-    # heat - low temperature water
-    :m_h_w_lt1,
-    :m_h_w_lt2,
-    :m_h_w_lt3,
-    :m_h_w_lt4,
-    :m_h_w_lt5,
+                                 # heat - low temperature water
+                                 :m_h_w_lt1,
+                                 :m_h_w_lt2,
+                                 :m_h_w_lt3,
+                                 :m_h_w_lt4,
+                                 :m_h_w_lt5,
 
-    # heat - high temperature water
-    :m_h_w_ht1,
-    :m_h_w_ht2,
-    :m_h_w_ht3,
-    :m_h_w_ht4,
-    :m_h_w_ht5,
-])
+                                 # heat - high temperature water
+                                 :m_h_w_ht1,
+                                 :m_h_w_ht2,
+                                 :m_h_w_ht3,
+                                 :m_h_w_ht4,
+                                 :m_h_w_ht5])
 
 """
 register_media(categories)
@@ -118,7 +116,7 @@ function register_media(categories::Vector{Symbol})
     end
 end
 
-register_media(category::Symbol) = register_media([category,])
+register_media(category::Symbol) = register_media([category])
 
 """
 Enumerations of the archetype of a component describing its general function.
@@ -127,7 +125,7 @@ These are described in more detail in the accompanying documentation of the simu
 model.
 """
 @enum(SystemFunction, sf_bounded_sink, sf_bounded_source, sf_fixed_sink,
-    sf_fixed_source, sf_transformer, sf_storage, sf_bus)
+      sf_fixed_source, sf_transformer, sf_storage, sf_bus)
 
 """
 Enumerations of a simulation step that can be performed on a component.
@@ -297,17 +295,33 @@ The following functions are effectively arithmetic operations on floats where on
 operands may be nothing. It is possible to overwrite the typical operators + and -,
 however this was deemed too dangerous.
 """
-function _sub(first::Float64, second::Float64) return first - second end
-function _sub(first::Nothing, second::Float64) return -second end
-function _sub(first::Float64, second::Nothing) return first end
-function _sub(first::Nothing, second::Nothing) return nothing end
+function _sub(first::Float64, second::Float64)
+    return first - second
+end
+function _sub(first::Nothing, second::Float64)
+    return -second
+end
+function _sub(first::Float64, second::Nothing)
+    return first
+end
+function _sub(first::Nothing, second::Nothing)
+    return nothing
+end
 
-function _add(first::Float64, second::Float64) return first + second end
-function _add(first::Nothing, second::Float64) return second end
-function _add(first::Float64, second::Nothing) return first end
-function _add(first::Nothing, second::Nothing) return nothing end
+function _add(first::Float64, second::Float64)
+    return first + second
+end
+function _add(first::Nothing, second::Float64)
+    return second
+end
+function _add(first::Float64, second::Nothing)
+    return first
+end
+function _add(first::Nothing, second::Nothing)
+    return nothing
+end
 
-function _abs(val::Union{Floathing, Vector{<:Floathing}})
+function _abs(val::Union{Floathing,Vector{<:Floathing}})
     if !isa(val, AbstractVector)
         val = [val]
     end
@@ -328,7 +342,7 @@ function _mean(vector::Union{Floathing,Vector{<:Floathing}})
     sum = _sum(vector)
     if number_of_values > 0 && sum !== nothing
         return sum / number_of_values
-    else 
+    else
         return nothing
     end
 end
@@ -357,10 +371,18 @@ function _weighted_mean(values::Union{Floathing,Vector{<:Floathing}},
     return _sum(valid_values .* normalized_weights)
 end
 
-function _isless(first::Nothing, second::Nothing) return false end
-function _isless(first::Float64, second::Nothing) return false end
-function _isless(first::Nothing, second::Float64) return true end
-function _isless(first::Float64, second::Float64) return first < second end
+function _isless(first::Nothing, second::Nothing)
+    return false
+end
+function _isless(first::Float64, second::Nothing)
+    return false
+end
+function _isless(first::Nothing, second::Float64)
+    return true
+end
+function _isless(first::Float64, second::Float64)
+    return first < second
+end
 
 """
     check_epsilon(value, sim_params)
@@ -372,7 +394,7 @@ the original value if value is out of the boundaries.
 function check_epsilon(value::Float64, sim_params::Dict{String,Any})
     if abs(value) < sim_params["epsilon"]
         return 0.0
-    else 
+    else
         return value
     end
 end
@@ -384,22 +406,20 @@ Add the given amount of energy (in Wh) to the balance of the interface.
 
 If the source or target of the interface is a bus, communicates the change to the bus.
 """
-function add!(
-    interface::SystemInterface,
-    change::Union{Floathing, Vector{<:Floathing}},
-    temperature::Temperature=nothing,
-    purpose_uac::Union{Stringing, Vector{Stringing}}=nothing,
-)
+function add!(interface::SystemInterface,
+              change::Union{Floathing,Vector{<:Floathing}},
+              temperature::Temperature=nothing,
+              purpose_uac::Union{Stringing,Vector{Stringing}}=nothing)
     interface.balance += sum(change)
     interface.sum_abs_change += sum(abs.(change))
 
     if temperature !== nothing
         if interface.temperature_min !== nothing && temperature < interface.temperature_min
             @warn ("Given temperature $temperature on interface $(interface.source.uac) " *
-                    "-> $(interface.target.uac) lower than minimum $(interface.temperature_min)")
+                   "-> $(interface.target.uac) lower than minimum $(interface.temperature_min)")
         elseif interface.temperature_max !== nothing && temperature > interface.temperature_max
             @warn ("Given temperature $temperature on interface $(interface.source.uac) " *
-                    "-> $(interface.target.uac) higher than maximum $(interface.temperature_max)")
+                   "-> $(interface.target.uac) higher than maximum $(interface.temperature_max)")
         end
     end
 
@@ -417,22 +437,20 @@ Subtract the given amount of energy (in Wh) from the balance of the interface.
 
 If the source or target of the interface is a bus, communicates the change to the bus.
 """
-function sub!(
-    interface::SystemInterface,
-    change::Union{Floathing, Vector{<:Floathing}},
-    temperature::Temperature=nothing,
-    purpose_uac::Union{Stringing, Vector{Stringing}}=nothing,
-)
+function sub!(interface::SystemInterface,
+              change::Union{Floathing,Vector{<:Floathing}},
+              temperature::Temperature=nothing,
+              purpose_uac::Union{Stringing,Vector{Stringing}}=nothing)
     interface.balance -= sum(change)
     interface.sum_abs_change += sum(abs.(change))
 
     if temperature !== nothing
         if interface.temperature_min !== nothing && temperature < interface.temperature_min
             @warn ("Given temperature $temperature on interface $(interface.source.uac) " *
-                    "-> $(interface.target.uac) lower than minimum $(interface.temperature_min)")
+                   "-> $(interface.target.uac) lower than minimum $(interface.temperature_min)")
         elseif interface.temperature_max !== nothing && temperature > interface.temperature_max
             @warn ("Given temperature $temperature on interface $(interface.source.uac) " *
-                    "-> $(interface.target.uac) higher than maximum $(interface.temperature_max)")
+                   "-> $(interface.target.uac) higher than maximum $(interface.temperature_max)")
         end
     end
 
@@ -448,10 +466,8 @@ end
 
 Set the balance of the interface to the given new value.
 """
-function set!(
-    interface::SystemInterface,
-    new_val::Float64
-)
+function set!(interface::SystemInterface,
+              new_val::Float64)
     interface.sum_abs_change += abs(interface.balance - new_val)
     interface.balance = new_val
 end
@@ -464,24 +480,18 @@ Set the minimum and maximum temperature for the interface.
 If the source or target of the interface is a bus, also calls the set_temperature!
 function on that bus.
 """
-function set_temperature!(
-    interface::SystemInterface,
-    temperature_min::Temperature=nothing,
-    temperature_max::Temperature=nothing
-)
+function set_temperature!(interface::SystemInterface,
+                          temperature_min::Temperature=nothing,
+                          temperature_max::Temperature=nothing)
     interface.temperature_min = highest(interface.temperature_min, temperature_min)
     interface.temperature_max = lowest(interface.temperature_max, temperature_max)
 
     if interface.source.sys_function == sf_bus
-        set_temperatures!(
-            interface.source, interface.target, false,
-            temperature_min, temperature_max
-        )
+        set_temperatures!(interface.source, interface.target, false,
+                          temperature_min, temperature_max)
     elseif interface.target.sys_function == sf_bus
-        set_temperatures!(
-            interface.target, interface.source, true,
-            temperature_min, temperature_max
-        )
+        set_temperatures!(interface.target, interface.source, true,
+                          temperature_min, temperature_max)
     end
 end
 
@@ -514,12 +524,10 @@ decreased if one of them is reduced. An analogy would be to divide the current t
 into smaller time steps, in each of which a different component is supplied or drawn with
 a subset of the maximum possible energy of the current time step.
 """
-function set_max_energy!(
-    interface::SystemInterface,
-    value::Union{Floathing, Vector{<:Floathing}},
-    purpose_uac::Union{Stringing, Vector{Stringing}} = nothing,
-    has_calculated_all_maxima::Bool = false
-)
+function set_max_energy!(interface::SystemInterface,
+                         value::Union{Floathing,Vector{<:Floathing}},
+                         purpose_uac::Union{Stringing,Vector{Stringing}}=nothing,
+                         has_calculated_all_maxima::Bool=false)
     if interface.source.sys_function == sf_bus
         set_max_energy!(interface.max_energy, value, purpose_uac, has_calculated_all_maxima)
         set_max_energy!(interface.source,
@@ -583,8 +591,8 @@ decreases the entries in max_energy.max_energy, starting with the first one, unt
 is fully distributed.
 """
 function reduce_max_energy!(max_energy::EnergySystems.MaxEnergy,
-                            amount::Union{Float64, Vector{Float64}},
-                            uac_to_reduce::Union{Stringing, Vector{Stringing}}=nothing)
+                            amount::Union{Float64,Vector{Float64}},
+                            uac_to_reduce::Union{Stringing,Vector{Stringing}}=nothing)
     for amount_idx in eachindex(amount)
         current_amount = length(amount) == 1 ? amount : amount[amount_idx]
         if uac_to_reduce === nothing || is_purpose_uac_nothing(max_energy)
@@ -592,7 +600,9 @@ function reduce_max_energy!(max_energy::EnergySystems.MaxEnergy,
                 to_reduce = min(current_amount, max_energy.max_energy[i])
                 max_energy.max_energy[i] -= to_reduce
                 current_amount -= to_reduce
-                if current_amount <= 0.0 break end
+                if current_amount <= 0.0
+                    break
+                end
             end
         else
             currrent_uac_to_reduce = isa(uac_to_reduce, AbstractVector) ? uac_to_reduce[amount_idx] : uac_to_reduce
@@ -622,8 +632,8 @@ to the first max_energy.max_energy as in this case, only one value should be pre
 connection or components that don't care).
 """
 function increase_max_energy!(max_energy::EnergySystems.MaxEnergy,
-                              amount::Union{Float64, Vector{Float64}},
-                              uac_to_increase::Union{Stringing, Vector{Stringing}}=nothing)
+                              amount::Union{Float64,Vector{Float64}},
+                              uac_to_increase::Union{Stringing,Vector{Stringing}}=nothing)
     for amount_idx in eachindex(amount)
         current_amount = length(amount) == 1 ? amount : amount[amount_idx]
         currrent_uac_to_increase = isa(uac_to_increase, AbstractVector) ? uac_to_increase[amount_idx] : uac_to_increase
@@ -643,7 +653,6 @@ function increase_max_energy!(max_energy::EnergySystems.MaxEnergy,
         end
     end
 end
-
 
 """
     max_energy_sum(max_energy)
@@ -665,12 +674,11 @@ Fills a MaxEnergy struct with given values.
 If the given values are scalars, they are converted into vectors.
 If `values` is empty, a zero is added to ensure accessibility.
 """
-function set_max_energy!(max_energy::EnergySystems.MaxEnergy, 
-                         values::Union{Floathing, Vector{<:Floathing}},
-                         purpose_uac::Union{Stringing, Vector{Stringing}},
+function set_max_energy!(max_energy::EnergySystems.MaxEnergy,
+                         values::Union{Floathing,Vector{<:Floathing}},
+                         purpose_uac::Union{Stringing,Vector{Stringing}},
                          has_calculated_all_maxima::Bool,
                          append::Bool=false)
-
     if !isa(values, AbstractVector)
         values = [values]
     end
@@ -715,7 +723,7 @@ Checks a MaxEnergy struct if the `purpose_uac` is nothing/empty (true), meaning 
 max_energy is not intended for a specific component.
 """
 function is_purpose_uac_nothing(max_energy::EnergySystems.MaxEnergy)
-    return (isempty(max_energy.purpose_uac) || 
+    return (isempty(max_energy.purpose_uac) ||
             max_energy.purpose_uac[1] === nothing && length(max_energy.purpose_uac) == 1)
 end
 
@@ -740,10 +748,8 @@ Returns the highest temperature of the two inputs and handles nothing-values:
 - If one of the inputs is nothing and one a float, the float will be returned.
 - If both of the inputs are nothing, nothing will be returned.
 """
-function highest(
-    temperature_1::Temperature,
-    temperature_2::Temperature
-)::Temperature
+function highest(temperature_1::Temperature,
+                 temperature_2::Temperature)::Temperature
     if temperature_1 !== nothing && temperature_2 !== nothing
         return max(temperature_1, temperature_2)
     elseif temperature_1 === nothing && temperature_2 !== nothing
@@ -767,7 +773,7 @@ function highest(temperature_vector::Vector{Temperature})::Temperature
         return nothing
     elseif n_temperatures == 1
         return temperature_vector[1]
-    else 
+    else
         current_highest = highest(temperature_vector[1], temperature_vector[2])
         if n_temperatures > 2
             for idx in 3:n_temperatures
@@ -786,10 +792,8 @@ Returns the lowest temperature of the two inputs and handles nothing-values:
 - If one of the inputs is nothing and one a float, the float will be returned.
 - If both of the inputs are nothing, nothing will be returned.
 """
-function lowest(
-    temperature_1::Temperature,
-    temperature_2::Temperature
-)::Temperature
+function lowest(temperature_1::Temperature,
+                temperature_2::Temperature)::Temperature
     if temperature_1 !== nothing && temperature_2 !== nothing
         return min(temperature_1, temperature_2)
     elseif temperature_1 === nothing && temperature_2 !== nothing
@@ -813,7 +817,7 @@ function lowest(temperature_vector::Vector{Temperature})::Temperature
         return nothing
     elseif n_temperatures == 1
         return temperature_vector[1]
-    else 
+    else
         current_lowest = lowest(temperature_vector[1], temperature_vector[2])
         if n_temperatures > 2
             for idx in 3:n_temperatures
@@ -992,15 +996,13 @@ function balance_on(interface::SystemInterface, unit::Component)::Vector{EnergyE
     input_sign = unit.uac == interface.target.uac ? -1 : +1
     purpose_uac = unit.uac == interface.target.uac ? interface.target.uac : interface.source.uac
 
-    return [EnEx(
-        balance=interface.balance,
-        energy_potential=(balance_written ? 0.0 : input_sign * get_max_energy(interface.max_energy)),
-        purpose_uac=purpose_uac,
-        temperature_min=interface.temperature_min,
-        temperature_max=interface.temperature_max,
-        pressure=nothing,
-        voltage=nothing
-    )]
+    return [EnEx(; balance=interface.balance,
+                 energy_potential=(balance_written ? 0.0 : input_sign * get_max_energy(interface.max_energy)),
+                 purpose_uac=purpose_uac,
+                 temperature_min=interface.temperature_min,
+                 temperature_max=interface.temperature_max,
+                 pressure=nothing,
+                 voltage=nothing)]
 end
 
 """
@@ -1028,7 +1030,7 @@ function balance(unit::Component)::Float64
         end
     end
 
-    return balance    
+    return balance
 end
 
 """
@@ -1079,11 +1081,9 @@ Perform the control calculations for the given component.
 - `components::Grouping`: A reference dict to all components in the project
 - `sim_params::Dict{String, Any}`: Project-wide simulation parameters
 """
-function control(
-    unit::Component,
-    components::Grouping,
-    sim_params::Dict{String,Any}
-)
+function control(unit::Component,
+                 components::Grouping,
+                 sim_params::Dict{String,Any})
     update(unit.controller)
 end
 
@@ -1096,10 +1096,8 @@ Calculate potential energy processing for the given component.
 - `unit::Component`: The component for which potentials are calculated
 - `sim_params::Dict{String, Any}`: Project-wide simulation parameters
 """
-function potential(
-    unit::Component,
-    sim_params::Dict{String,Any}
-)
+function potential(unit::Component,
+                   sim_params::Dict{String,Any})
     # default implementation is to do nothing
 end
 
@@ -1112,10 +1110,8 @@ Perform the processing calculations for the given component.
 - `unit::Component`: The component that is processed
 - `sim_params::Dict{String, Any}`: Project-wide simulation parameters
 """
-function process(
-    unit::Component,
-    sim_params::Dict{String,Any}
-)
+function process(unit::Component,
+                 sim_params::Dict{String,Any})
     # default implementation is to do nothing
 end
 
@@ -1130,10 +1126,8 @@ For non-storage components this function does nothing.
 - `unit::Component`: The storage loading excess energy
 - `sim_params::Dict{String, Any}`: Project-wide simulation parameters
 """
-function load(
-    unit::Component,
-    sim_params::Dict{String,Any}
-)
+function load(unit::Component,
+              sim_params::Dict{String,Any})
     # default implementation is to do nothing
 end
 
@@ -1169,7 +1163,7 @@ Possible output formats are:
 # Returns:
 - Bool: true if a figure was created, false if no figure was created.
 """
-function plot_optional_figures(unit::Component, 
+function plot_optional_figures(unit::Component,
                                output_path::String,
                                output_formats::Vector{Any},
                                sim_params::Dict{String,Any})
@@ -1189,7 +1183,7 @@ media of the data outputs. A medium is only needed for inputs and outputs, not f
 """
 function output_values(unit::Component)::Vector{String}
     return []  # base implementation returns an empty output vector as the output values 
-               # have to be specified in every component.
+    # have to be specified in every component.
 end
 
 """
@@ -1268,7 +1262,6 @@ include("control_modules/economical_discharge.jl")
 include("control_modules/profile_limited.jl")
 include("control_modules/storage_driven.jl")
 
-
 """
     link_output_with(unit, components)
 
@@ -1287,14 +1280,14 @@ function link_output_with(unit::Component, components::Grouping)
         for component in each(components)
             if isa(component, Bus)
                 if unit.medium == component.medium
-                    connection = SystemInterface(source=unit, target=component)
+                    connection = SystemInterface(; source=unit, target=component)
                     push!(component.input_interfaces, connection)
                     push!(unit.output_interfaces, connection)
                 end
             else
                 for in_medium in keys(component.input_interfaces)
                     if in_medium == unit.medium
-                        connection = SystemInterface(source=unit, target=component)
+                        connection = SystemInterface(; source=unit, target=component)
                         component.input_interfaces[in_medium] = connection
                         push!(unit.output_interfaces, connection)
                     end
@@ -1306,14 +1299,14 @@ function link_output_with(unit::Component, components::Grouping)
             for component in each(components)
                 if isa(component, Bus)
                     if out_medium == component.medium
-                        connection = SystemInterface(source=unit, target=component)
+                        connection = SystemInterface(; source=unit, target=component)
                         push!(component.input_interfaces, connection)
                         unit.output_interfaces[out_medium] = connection
                     end
                 else
                     for in_medium in keys(component.input_interfaces)
                         if out_medium == in_medium
-                            connection = SystemInterface(source=unit, target=component)
+                            connection = SystemInterface(; source=unit, target=component)
                             unit.output_interfaces[out_medium] = connection
                             component.input_interfaces[in_medium] = connection
                         end
@@ -1358,17 +1351,15 @@ Each chain is a set of interconnected busses of the same medium. For an example
 `components::Grouping`: All components of the energy systems
 `sim_params::Dict{String,Any}`: Simulation parameters
 """
-function merge_bus_chains(
-    chains::Vector{Set{Component}},
-    components::Grouping,
-    sim_params::Dict{String,Any}
-)
+function merge_bus_chains(chains::Vector{Set{Component}},
+                          components::Grouping,
+                          sim_params::Dict{String,Any})
     for chain in chains
         if length(chain) < 2
             continue
         end
 
-        comp_as_grouping = Grouping(comp.uac=>comp for comp in chain)
+        comp_as_grouping = Grouping(comp.uac => comp for comp in chain)
         merged = merge_busses(comp_as_grouping, components)
         for bus in chain
             bus.proxy = merged
@@ -1391,10 +1382,8 @@ Check the energy balance of the given components and return warnings of any viol
 - `Vector{Tuple{String, Float64}}`: A list of tuples, where each tuple is the key of the
     component that has a non-zero energy balance and the value of that balance.
 """
-function check_balances(
-    components::Grouping,
-    epsilon::Float64
-)::Vector{Tuple{String,Float64}}
+function check_balances(components::Grouping,
+                        epsilon::Float64)::Vector{Tuple{String,Float64}}
     warnings = []
 
     for (key, unit) in pairs(components)
@@ -1439,11 +1428,9 @@ Perform the simulation steps of one time step for the given components in the gi
 In this example the control of component A is performed first, then control and processing of
 component B and finally processing of component A.
 """
-function perform_steps(
-    components::Grouping,
-    order_of_operations::StepInstructions,
-    sim_params::Dict{String,Any}
-)
+function perform_steps(components::Grouping,
+                       order_of_operations::StepInstructions,
+                       sim_params::Dict{String,Any})
     for entry in order_of_operations
         unit = components[entry[1]]
         step = entry[2]
@@ -1477,34 +1464,34 @@ The function also checks whether more than one temperature source is specified a
 """
 function get_temperature_profile_from_config(config::Dict{String,Any}, sim_params::Dict{String,Any}, uac::String)
     # check input
-    if (    haskey(config, "temperature_profile_file_path") + 
-            haskey(config, "temperature_from_global_file") + 
-            haskey(config, "constant_temperature")
-            ) > 1
+    if (haskey(config, "temperature_profile_file_path") +
+        haskey(config, "temperature_from_global_file") +
+        haskey(config, "constant_temperature")) > 1
+        # end of condition
         @warn "Two or more temperature profile sources for $(uac) have been specified in the input file!"
     end
 
     # determine temperature
-    if haskey(config,"temperature_profile_file_path")
+    if haskey(config, "temperature_profile_file_path")
         @info "For '$uac', the temperature profile is taken from the user-defined .prf file."
-        return Profile(config["temperature_profile_file_path"], sim_params) 
+        return Profile(config["temperature_profile_file_path"], sim_params)
     elseif haskey(config, "constant_temperature") && config["constant_temperature"] isa Number
         @info "For '$uac', a constant temperature of $(config["constant_temperature"]) °C is set."
         return nothing
     elseif haskey(config, "temperature_from_global_file") && haskey(sim_params, "weather_data")
-        if any(occursin(config["temperature_from_global_file"], string(field_name)) for field_name in fieldnames(typeof(sim_params["weather_data"])))
-            @info "For '$uac', the temperature profile is taken from the project-wide weather file: $(config["temperature_from_global_file"])"                
+        if any(occursin(config["temperature_from_global_file"], string(field_name))
+               for field_name in fieldnames(typeof(sim_params["weather_data"])))
+            @info "For '$uac', the temperature profile is taken from the project-wide weather file: $(config["temperature_from_global_file"])"
             return getfield(sim_params["weather_data"], Symbol(config["temperature_from_global_file"]))
         else
             @error "For '$uac', the'temperature_from_global_file' has to be one of: $(join(string.(fieldnames(typeof(sim_params["weather_data"]))), ", "))."
             throw(InputError)
         end
-    else            
+    else
         @info "For '$uac', no temperature is set."
         return nothing
     end
 end
-
 
 """
 get_ambient_temperature_profile_from_config(config, simulation_parameter, uac)
@@ -1516,7 +1503,9 @@ If temperature_from_global_file is set to a valid entry of the global weather fi
 
 The function also checks whether more than one temperature source is specified and throws a warning if this is the case.
 """
-function get_ambient_temperature_profile_from_config(config::Dict{String,Any}, sim_params::Dict{String,Any}, uac::String)
+function get_ambient_temperature_profile_from_config(config::Dict{String,Any},
+                                                     sim_params::Dict{String,Any},
+                                                     uac::String)
     # check input
     if (haskey(config, "ambient_temperature_profile_path") + haskey(config, "ambient_temperature_from_global_file")) > 1
         @warn "Two or more temperature profile sources for $(uac) have been specified in the input file!"
@@ -1527,7 +1516,8 @@ function get_ambient_temperature_profile_from_config(config::Dict{String,Any}, s
         @info "For '$uac', the given ambient temperature profile is chosen."
         return Profile(config["ambient_temperature_profile_path"], sim_params)
     elseif haskey(config, "ambient_temperature_from_global_file") && haskey(sim_params, "weather_data")
-        if any(occursin(config["ambient_temperature_from_global_file"], string(field_name)) for field_name in fieldnames(typeof(sim_params["weather_data"])))
+        if any(occursin(config["ambient_temperature_from_global_file"], string(field_name))
+               for field_name in fieldnames(typeof(sim_params["weather_data"])))
             @info "For '$uac', the temperature profile is taken from the project-wide weather file: $(config["ambient_temperature_from_global_file"])"
             return getfield(sim_params["weather_data"], Symbol(config["ambient_temperature_from_global_file"]))
         else

--- a/src/energy_systems/control.jl
+++ b/src/energy_systems/control.jl
@@ -73,29 +73,21 @@ end
 """
 Constructor of StateMachine for non-default fields.
 """
-StateMachine(
-    state::UInt,
-    state_names::Dict{UInt,String},
-    transitions::Dict{UInt,TruthTable}
-) = StateMachine(
-    state,
-    state_names,
-    transitions,
-    UInt(0)
-)
+StateMachine(state::UInt,
+state_names::Dict{UInt,String},
+transitions::Dict{UInt,TruthTable}) = StateMachine(state,
+                                                   state_names,
+                                                   transitions,
+                                                   UInt(0))
 
 """
 Default constructor of StateMachine that creates a state machine with only one state called
 "Default" and no transitions (as there no other states).
 """
-StateMachine() = StateMachine(
-    UInt(1),
-    Dict(UInt(1) => "Default"),
-    Dict(UInt(1) => TruthTable(
-        conditions=Vector(),
-        table_data=Dict()
-    ))
-)
+StateMachine() = StateMachine(UInt(1),
+                              Dict(UInt(1) => "Default"),
+                              Dict(UInt(1) => TruthTable(; conditions=Vector(),
+                                                         table_data=Dict())))
 
 """
 Advances the given state machine by checking the conditions in its current state.
@@ -155,27 +147,23 @@ mutable struct Controller
     modules::Vector{ControlModule}
 
     function Controller(config::Union{Nothing,Dict{String,Any}})::Controller
-        return new(
-            Base.merge( # parameters
-                Dict{String,Any}(
-                    "aggregation_plr_limit" => "max",
-                    "aggregation_charge" => "all",
-                    "aggregation_discharge" => "all",
-                    "consider_m_el_in" => true,
-                    "consider_m_el_out" => true,
-                    "consider_m_gas_in" => true,
-                    "consider_m_fuel_in" => true,
-                    "consider_m_h2_out" => true,
-                    "consider_m_o2_out" => true,
-                    "consider_m_heat_out" => true,
-                    "consider_m_heat_ht_out" => true,
-                    "consider_m_heat_lt_out" => true,
-                    "consider_m_heat_in" => true
-                ),
-                config === nothing ? Dict{String,Any}() : config
-            ),
-            [] # modules
-        )
+        return new(Base.merge(Dict{String,Any}(
+                                  "aggregation_plr_limit" => "max",
+                                  "aggregation_charge" => "all",
+                                  "aggregation_discharge" => "all",
+                                  "consider_m_el_in" => true,
+                                  "consider_m_el_out" => true,
+                                  "consider_m_gas_in" => true,
+                                  "consider_m_fuel_in" => true,
+                                  "consider_m_h2_out" => true,
+                                  "consider_m_o2_out" => true,
+                                  "consider_m_heat_out" => true,
+                                  "consider_m_heat_ht_out" => true,
+                                  "consider_m_heat_lt_out" => true,
+                                  "consider_m_heat_in" => true,
+                              ),
+                              config === nothing ? Dict{String,Any}() : config),
+                   [])
     end
 end
 
@@ -197,9 +185,7 @@ is to allow storage loading.
 - `Bool`: True if the parameter is set and is false, true otherwise
 """
 function load_storages(controller::Controller, medium::Symbol)::Bool
-    return default(
-        controller.parameters, "load_storages " * String(medium), true
-    )
+    return default(controller.parameters, "load_storages " * String(medium), true)
 end
 
 """
@@ -215,9 +201,7 @@ is to allow storage unloading.
 - `Bool`: True if the parameter is set and is false, true otherwise
 """
 function unload_storages(controller::Controller, medium::Symbol)::Bool
-    return default(
-        controller.parameters, "unload_storages " * String(medium), true
-    )
+    return default(controller.parameters, "unload_storages " * String(medium), true)
 end
 
 """
@@ -264,11 +248,9 @@ have a value larger zero for the component to run.
 - `Float64`: The aggregated upper PLR limit
 """
 function upper_plr_limit(controller::Controller, sim_params::Dict{String,Any})::Float64
-    limits = collect(
-        upper_plr_limit(mod, sim_params)
-        for mod in controller.modules
-        if has_method_for(mod, cmf_upper_plr_limit)
-    )
+    limits = collect(upper_plr_limit(mod, sim_params)
+                     for mod in controller.modules
+                     if has_method_for(mod, cmf_upper_plr_limit))
     if length(limits) == 0
         return 1.0
     end
@@ -297,11 +279,9 @@ method "any" it is sufficient if any one module returns true.
 - `Bool`: The aggregated charging flag with true meaning charging is allowed
 """
 function charge_is_allowed(controller::Controller, sim_params::Dict{String,Any})::Bool
-    flags = collect(
-        charge_is_allowed(mod, sim_params)
-        for mod in controller.modules
-        if has_method_for(mod, cmf_charge_is_allowed)
-    )
+    flags = collect(charge_is_allowed(mod, sim_params)
+                    for mod in controller.modules
+                    if has_method_for(mod, cmf_charge_is_allowed))
     if length(flags) == 0
         return true
     end
@@ -330,11 +310,9 @@ aggregation method "any" it is sufficient if any one module returns true.
 - `Bool`: The aggregated charging flag with true meaning discharging is allowed
 """
 function discharge_is_allowed(controller::Controller, sim_params::Dict{String,Any})::Bool
-    flags = collect(
-        discharge_is_allowed(mod, sim_params)
-        for mod in controller.modules
-        if has_method_for(mod, cmf_discharge_is_allowed)
-    )
+    flags = collect(discharge_is_allowed(mod, sim_params)
+                    for mod in controller.modules
+                    if has_method_for(mod, cmf_discharge_is_allowed))
     if length(flags) == 0
         return true
     end

--- a/src/energy_systems/heat_producers/heat_pump.jl
+++ b/src/energy_systems/heat_producers/heat_pump.jl
@@ -35,87 +35,67 @@ mutable struct HeatPump <: Component
         m_heat_in = Symbol(default(config, "m_heat_in", "m_h_w_lt1"))
         register_media([m_el_in, m_heat_out, m_heat_in])
 
-        return new(
-            uac, # uac
-            Controller(default(config, "control_parameters", nothing)),
-            sf_transformer, # sys_function
-            InterfaceMap( # input_interfaces
-                m_heat_in => nothing,
-                m_el_in => nothing
-            ),
-            InterfaceMap( # output_interfaces
-                m_heat_out => nothing
-            ),
-            m_el_in,
-            m_heat_out,
-            m_heat_in,
-            config["power_th"], # power_th
-            default(config, "min_power_fraction", 0.2),
-            default(config, "min_run_time", 0),
-            default(config, "constant_cop", nothing),
-            default(config, "output_temperature", nothing),
-            default(config, "input_temperature", nothing),
-            0.0, # cop
-            0.0, # losses
-            0.0, # mixing temperature in the input interface
-            0.0, # mixing temperature in the output interface
-        )
+        return new(uac, # uac
+                   Controller(default(config, "control_parameters", nothing)),
+                   sf_transformer, # sys_function
+                   InterfaceMap(m_heat_in => nothing, # input_interfaces
+                                m_el_in => nothing),
+                   InterfaceMap(m_heat_out => nothing), # output_interfaces
+                   m_el_in,
+                   m_heat_out,
+                   m_heat_in,
+                   config["power_th"], # power_th
+                   default(config, "min_power_fraction", 0.2),
+                   default(config, "min_run_time", 0),
+                   default(config, "constant_cop", nothing),
+                   default(config, "output_temperature", nothing),
+                   default(config, "input_temperature", nothing),
+                   0.0, # cop
+                   0.0, # losses
+                   0.0, # mixing temperature in the input interface
+                   0.0) # mixing temperature in the output interface
     end
 end
 
 function initialise!(unit::HeatPump, sim_params::Dict{String,Any})
-    set_storage_transfer!(
-        unit.input_interfaces[unit.m_heat_in],
-        unload_storages(unit.controller, unit.m_heat_in)
-    )
-    set_storage_transfer!(
-        unit.input_interfaces[unit.m_el_in],
-        unload_storages(unit.controller, unit.m_el_in)
-    )
-    set_storage_transfer!(
-        unit.output_interfaces[unit.m_heat_out],
-        load_storages(unit.controller, unit.m_heat_out)
-    )
+    set_storage_transfer!(unit.input_interfaces[unit.m_heat_in],
+                          unload_storages(unit.controller, unit.m_heat_in))
+    set_storage_transfer!(unit.input_interfaces[unit.m_el_in],
+                          unload_storages(unit.controller, unit.m_el_in))
+    set_storage_transfer!(unit.output_interfaces[unit.m_heat_out],
+                          load_storages(unit.controller, unit.m_heat_out))
 end
 
-function control(
-    unit::HeatPump,
-    components::Grouping,
-    sim_params::Dict{String,Any}
-)
+function control(unit::HeatPump, components::Grouping, sim_params::Dict{String,Any})
     update(unit.controller)
 
     # for fixed input/output temperatures, overwrite the interface with those. otherwise
     # highest will choose the interface's temperature (including nothing)
     if unit.output_temperature !== nothing
-        set_temperature!(
-            unit.output_interfaces[unit.m_heat_out],
-            unit.output_temperature,
-            unit.output_temperature
-        )
+        set_temperature!(unit.output_interfaces[unit.m_heat_out],
+                         unit.output_temperature,
+                         unit.output_temperature)
     end
     if unit.input_temperature !== nothing
-        set_temperature!(
-            unit.input_interfaces[unit.m_heat_in],
-            unit.input_temperature,
-            unit.input_temperature
-        )
+        set_temperature!(unit.input_interfaces[unit.m_heat_in],
+                         unit.input_temperature,
+                         unit.input_temperature)
     end
 end
 
-function set_max_energies!(
-    unit::HeatPump,
-    el_in::Union{Floathing, Vector{<:Floathing}},
-    heat_in::Union{Floathing, Vector{<:Floathing}},
-    heat_out::Union{Floathing, Vector{<:Floathing}},
-    purpose_uac_heat_in::Union{Stringing, Vector{Stringing}}=nothing,
-    purpose_uac_heat_out::Union{Stringing, Vector{Stringing}}=nothing,
-    has_calculated_all_maxima_heat_in::Bool=false,
-    has_calculated_all_maxima_heat_out::Bool=false
-)
+function set_max_energies!(unit::HeatPump,
+                           el_in::Union{Floathing,Vector{<:Floathing}},
+                           heat_in::Union{Floathing,Vector{<:Floathing}},
+                           heat_out::Union{Floathing,Vector{<:Floathing}},
+                           purpose_uac_heat_in::Union{Stringing,Vector{Stringing}}=nothing,
+                           purpose_uac_heat_out::Union{Stringing,Vector{Stringing}}=nothing,
+                           has_calculated_all_maxima_heat_in::Bool=false,
+                           has_calculated_all_maxima_heat_out::Bool=false)
     set_max_energy!(unit.input_interfaces[unit.m_el_in], el_in)
-    set_max_energy!(unit.input_interfaces[unit.m_heat_in], heat_in, purpose_uac_heat_in, has_calculated_all_maxima_heat_in)
-    set_max_energy!(unit.output_interfaces[unit.m_heat_out], heat_out, purpose_uac_heat_out, has_calculated_all_maxima_heat_out)
+    set_max_energy!(unit.input_interfaces[unit.m_heat_in], heat_in, purpose_uac_heat_in,
+                    has_calculated_all_maxima_heat_in)
+    set_max_energy!(unit.output_interfaces[unit.m_heat_out], heat_out, purpose_uac_heat_out,
+                    has_calculated_all_maxima_heat_out)
 end
 
 function dynamic_cop(in_temp::Temperature, out_temp::Temperature)::Union{Nothing,Float64}
@@ -127,20 +107,16 @@ function dynamic_cop(in_temp::Temperature, out_temp::Temperature)::Union{Nothing
     return 0.4 * (273.15 + out_temp) / (out_temp - in_temp)
 end
 
-function check_el_in(
-    unit::HeatPump,
-    sim_params::Dict{String,Any}
-)
+function check_el_in(unit::HeatPump, sim_params::Dict{String,Any})
     if unit.controller.parameters["consider_m_el_in"] == true
         if (unit.input_interfaces[unit.m_el_in].source.sys_function == sf_transformer  # HP has direct connection to a transfomer...
-            && is_max_energy_nothing(unit.input_interfaces[unit.m_el_in].max_energy)   # ...and none of them have had their potential step
-        )
+            &&
+            is_max_energy_nothing(unit.input_interfaces[unit.m_el_in].max_energy))
+            # end of condition
             return (Inf)
         else
-            exchanges = balance_on(
-                unit.input_interfaces[unit.m_el_in],
-                unit.input_interfaces[unit.m_el_in].source
-            )
+            exchanges = balance_on(unit.input_interfaces[unit.m_el_in],
+                                   unit.input_interfaces[unit.m_el_in].source)
             potential_energy_el = balance(exchanges) + energy_potential(exchanges)
             if potential_energy_el <= sim_params["epsilon"]
                 return (0.0)
@@ -152,74 +128,57 @@ function check_el_in(
     end
 end
 
-function check_heat_in(
-    unit::HeatPump,
-    sim_params::Dict{String,Any}
-)
+function check_heat_in(unit::HeatPump, sim_params::Dict{String,Any})
     if unit.controller.parameters["consider_m_heat_in"] == true
         if (unit.input_interfaces[unit.m_heat_in].source.sys_function == sf_transformer  # HP has direct connection to a transfomer...
-             && is_max_energy_nothing(unit.input_interfaces[unit.m_heat_in].max_energy)  # ...and none of them have had their potential step
-        )
+            &&
+            is_max_energy_nothing(unit.input_interfaces[unit.m_heat_in].max_energy))
+            # end of condition
             return ([Inf],
-                    [unit.input_interfaces[unit.m_heat_in].temperature_min], 
+                    [unit.input_interfaces[unit.m_heat_in].temperature_min],
                     [unit.input_interfaces[unit.m_heat_in].temperature_max],
-                    [unit.input_interfaces[unit.m_heat_in].source.uac]
-                )
+                    [unit.input_interfaces[unit.m_heat_in].source.uac])
         else
-            exchanges = balance_on(
-                unit.input_interfaces[unit.m_heat_in],
-                unit.input_interfaces[unit.m_heat_in].source
-            )
-            return (
-                [e.balance + e.energy_potential for e in exchanges],
-                temp_min_all(exchanges),
-                temp_max_all(exchanges),
-                [e.purpose_uac for e in exchanges]
-            )
+            exchanges = balance_on(unit.input_interfaces[unit.m_heat_in],
+                                   unit.input_interfaces[unit.m_heat_in].source)
+            return ([e.balance + e.energy_potential for e in exchanges],
+                    temp_min_all(exchanges),
+                    temp_max_all(exchanges),
+                    [e.purpose_uac for e in exchanges])
         end
     else
         return ([Inf],
-                [unit.input_interfaces[unit.m_heat_in].temperature_min], 
+                [unit.input_interfaces[unit.m_heat_in].temperature_min],
                 [unit.input_interfaces[unit.m_heat_in].temperature_max],
-                [unit.input_interfaces[unit.m_heat_in].source.uac]
-            )
+                [unit.input_interfaces[unit.m_heat_in].source.uac])
     end
 end
 
-function check_heat_out(
-    unit::HeatPump,
-    sim_params::Dict{String,Any}
-)
+function check_heat_out(unit::HeatPump, sim_params::Dict{String,Any})
     if unit.controller.parameters["consider_m_heat_out"] == true
         if (unit.output_interfaces[unit.m_heat_out].target.sys_function == sf_transformer   # HP has direct connection to a transfomer...
-            && is_max_energy_nothing(unit.output_interfaces[unit.m_heat_out].max_energy)    # ...and none of them have had their potential step
-        )
+            &&
+            is_max_energy_nothing(unit.output_interfaces[unit.m_heat_out].max_energy))
+            # end of condition
             return ([-Inf],
-                    [unit.output_interfaces[unit.m_heat_out].temperature_min], 
+                    [unit.output_interfaces[unit.m_heat_out].temperature_min],
                     [unit.output_interfaces[unit.m_heat_out].temperature_max],
-                    [unit.output_interfaces[unit.m_heat_out].target.uac]
-                )
+                    [unit.output_interfaces[unit.m_heat_out].target.uac])
         else
-            exchanges = balance_on(
-                unit.output_interfaces[unit.m_heat_out],
-                unit.output_interfaces[unit.m_heat_out].target
-            )
-            return (
-                [e.balance + e.energy_potential for e in exchanges],
-                temp_min_all(exchanges),
-                temp_max_all(exchanges),
-                [e.purpose_uac for e in exchanges]
-            )
+            exchanges = balance_on(unit.output_interfaces[unit.m_heat_out],
+                                   unit.output_interfaces[unit.m_heat_out].target)
+            return ([e.balance + e.energy_potential for e in exchanges],
+                    temp_min_all(exchanges),
+                    temp_max_all(exchanges),
+                    [e.purpose_uac for e in exchanges])
         end
     else
         return ([-Inf],
-                [unit.output_interfaces[unit.m_heat_out].temperature_min], 
+                [unit.output_interfaces[unit.m_heat_out].temperature_min],
                 [unit.output_interfaces[unit.m_heat_out].temperature_max],
-                [unit.output_interfaces[unit.m_heat_out].target.uac]
-                )
+                [unit.output_interfaces[unit.m_heat_out].target.uac])
     end
 end
-
 
 function calculate_energies_heatpump(unit::HeatPump,
                                      sim_params::Dict{String,Any},
@@ -243,12 +202,10 @@ function calculate_energies_heatpump(unit::HeatPump,
 
     current_in_idx = 1
     current_out_idx = 1
-    while (
-           sum(available_el_in; init=0.0) > sim_params["epsilon"]
+    while (sum(available_el_in; init=0.0) > sim_params["epsilon"]
            && sum(available_heat_in; init=0.0) > sim_params["epsilon"]
            && sum(available_heat_out; init=0.0) > sim_params["epsilon"]
-           && max_usage_fraction * watt_to_wh(unit.power_th) - sum(layers_heat_out; init=0.0) > sim_params["epsilon"]
-       )
+           && max_usage_fraction * watt_to_wh(unit.power_th) - sum(layers_heat_out; init=0.0) > sim_params["epsilon"])
         # find first non-zero index
         while available_heat_in[current_in_idx] <= sim_params["epsilon"]
             current_in_idx += 1
@@ -266,12 +223,14 @@ function calculate_energies_heatpump(unit::HeatPump,
             end
         else
             # skip layer if given fixed input temperature is not within the temperature band of the layer
-            if (
-                in_temps_min[current_in_idx] !== nothing
-                   && in_temps_min[current_in_idx] > unit.input_temperature
-                || in_temps_max[current_in_idx] !== nothing
-                   && in_temps_max[current_in_idx] < unit.input_temperature
-            )
+            if (in_temps_min[current_in_idx] !== nothing
+                &&
+                in_temps_min[current_in_idx] > unit.input_temperature
+                ||
+                in_temps_max[current_in_idx] !== nothing
+                &&
+                in_temps_max[current_in_idx] < unit.input_temperature)
+                # end of condition
                 available_heat_in[current_in_idx] = 0.0
                 current_in_idx += 1
                 continue
@@ -288,27 +247,27 @@ function calculate_energies_heatpump(unit::HeatPump,
             end
         else
             # skip layer if given fixed output temperature is not within the temperature band of the layer
-            if (
-                out_temps_min[current_out_idx] !== nothing
-                    && out_temps_min[current_out_idx] > unit.output_temperature
-                || out_temps_max[current_out_idx] !== nothing
-                    && out_temps_max[current_out_idx] < unit.output_temperature
-            )
+            if (out_temps_min[current_out_idx] !== nothing
+                &&
+                out_temps_min[current_out_idx] > unit.output_temperature
+                ||
+                out_temps_max[current_out_idx] !== nothing
+                &&
+                out_temps_max[current_out_idx] < unit.output_temperature)
+                # end of condition
                 available_heat_out[current_out_idx] = 0.0
                 current_out_idx += 1
                 continue
             else
                 current_out_temp = unit.output_temperature
             end
-        end 
+        end
 
         if current_in_temp >= current_out_temp && unit.constant_cop === nothing
             # bypass only if no constant cop is given
-            heat_transfer = minimum([
-                available_heat_in[current_in_idx],
-                available_heat_out[current_out_idx],
-                max_usage_fraction * watt_to_wh(unit.power_th) - sum(layers_heat_out; init=0.0)
-            ])
+            heat_transfer = minimum([available_heat_in[current_in_idx],
+                                     available_heat_out[current_out_idx],
+                                     max_usage_fraction * watt_to_wh(unit.power_th) - sum(layers_heat_out; init=0.0)])
             used_heat_in = heat_transfer
             used_heat_out = heat_transfer
             # The el. energy can not be zero as this would lead to problems in process step
@@ -321,8 +280,8 @@ function calculate_energies_heatpump(unit::HeatPump,
         else
             # calculate cop
             cop = unit.constant_cop === nothing ?
-                dynamic_cop(current_in_temp, current_out_temp) :
-                unit.constant_cop
+                  dynamic_cop(current_in_temp, current_out_temp) :
+                  unit.constant_cop
             if cop === nothing
                 @error ("Input and/or output temperature for heatpump $(unit.uac) is not given. Provide temperatures or fixed cop.")
                 throw(InputError)
@@ -335,7 +294,7 @@ function calculate_energies_heatpump(unit::HeatPump,
             used_heat_out = used_heat_in + used_el_in
 
             # check heat out as limiter, also checking for limit of heat pump
-            max_heat_out = min(available_heat_out[current_out_idx], 
+            max_heat_out = min(available_heat_out[current_out_idx],
                                max_usage_fraction * watt_to_wh(unit.power_th) - sum(layers_heat_out; init=0.0))
             if used_heat_out > max_heat_out
                 used_heat_out = max_heat_out
@@ -380,7 +339,6 @@ function reorder_energies(unit,
                           temps_min,
                           temps_max,
                           uacs)
-
     function highest_first_with_nothing(a, b)
         if a === nothing
             return false
@@ -393,13 +351,13 @@ function reorder_energies(unit,
 
     # TODO: Implement contol module!    
     if order == "highest_in_temps_max_first"
-        order_idx = sortperm(temps_max, by=x -> x, lt=highest_first_with_nothing)
+        order_idx = sortperm(temps_max; by=x -> x, lt=highest_first_with_nothing)
         energies = energies[order_idx]
         temps_min = temps_min[order_idx]
         temps_max = temps_max[order_idx]
         uacs = uacs[order_idx]
     elseif order == "smallest_out_temps_min_first"
-        order_idx = reverse(sortperm(temps_min, by=x -> x, lt=highest_first_with_nothing))
+        order_idx = reverse(sortperm(temps_min; by=x -> x, lt=highest_first_with_nothing))
         energies = energies[order_idx]
         temps_min = temps_min[order_idx]
         temps_max = temps_max[order_idx]
@@ -408,10 +366,7 @@ function reorder_energies(unit,
     return energies, temps_min, temps_max, uacs
 end
 
-function calculate_energies(
-    unit::HeatPump,
-    sim_params::Dict{String,Any}
-)
+function calculate_energies(unit::HeatPump, sim_params::Dict{String,Any})
     # get usage fraction from control modules
     max_usage_fraction = upper_plr_limit(unit.controller, sim_params)
     if max_usage_fraction <= 0.0
@@ -422,13 +377,13 @@ function calculate_energies(
     # vectors to allow for temperautre layers, while the electricity input is a scalar
     potential_energy_el = check_el_in(unit, sim_params)
     potentials_energies_heat_in,
-        in_temps_min,
-        in_temps_max,
-        in_uacs = check_heat_in(unit, sim_params)
-    potentials_energies_heat_out, 
-        out_temps_min,
-        out_temps_max,
-        out_uacs = check_heat_out(unit, sim_params)
+    in_temps_min,
+    in_temps_max,
+    in_uacs = check_heat_in(unit, sim_params)
+    potentials_energies_heat_out,
+    out_temps_min,
+    out_temps_max,
+    out_uacs = check_heat_out(unit, sim_params)
 
     # in the following we want to work with positive values as it is easier
     potentials_energies_heat_in = abs.(potentials_energies_heat_in)
@@ -472,7 +427,7 @@ function calculate_energies(
         @warn "The heat pump $(unit.uac) has unknown energies in both its inputs and outputs. This cannot be resolved. " *
               "Please check the order of operation and make sure that either the inputs or the outputs have been fully calculated " *
               "before the heat pump $(unit.uac) has its potential step."
-    elseif heat_in_has_inf_energy 
+    elseif heat_in_has_inf_energy
         for heat_in_idx in eachindex(potentials_energies_heat_in)
             layers_el_in_temp,
             layers_heat_in_temp,
@@ -480,19 +435,19 @@ function calculate_energies(
             layers_heat_in_uac_temp,
             layers_heat_out_temp,
             layers_heat_out_temperature_temp,
-            layers_heat_out_uac_temp  = calculate_energies_heatpump(unit,
-                                                            sim_params,
-                                                            copy(potential_energy_el),
-                                                            [Inf],
-                                                            copy(potentials_energies_heat_out),
-                                                            max_usage_fraction,
-                                                            [in_temps_min[heat_in_idx]],
-                                                            [in_temps_max[heat_in_idx]],
-                                                            [in_uacs[heat_in_idx]],
-                                                            out_temps_min,
-                                                            out_temps_max,
-                                                            out_uacs)
-                                                        
+            layers_heat_out_uac_temp = calculate_energies_heatpump(unit,
+                                                                   sim_params,
+                                                                   copy(potential_energy_el),
+                                                                   [Inf],
+                                                                   copy(potentials_energies_heat_out),
+                                                                   max_usage_fraction,
+                                                                   [in_temps_min[heat_in_idx]],
+                                                                   [in_temps_max[heat_in_idx]],
+                                                                   [in_uacs[heat_in_idx]],
+                                                                   out_temps_min,
+                                                                   out_temps_max,
+                                                                   out_uacs)
+
             append!(layers_heat_in, layers_heat_in_temp)
             append!(layers_heat_in_temperature, layers_heat_in_temperature_temp)
             append!(layers_heat_in_uac, layers_heat_in_uac_temp)
@@ -521,19 +476,19 @@ function calculate_energies(
             layers_heat_in_uac_temp,
             layers_heat_out_temp,
             layers_heat_out_temperature_temp,
-            layers_heat_out_uac_temp  = calculate_energies_heatpump(unit,
-                                                            sim_params,
-                                                            copy(potential_energy_el),
-                                                            copy(potentials_energies_heat_in),
-                                                            [Inf],
-                                                            max_usage_fraction,
-                                                            in_temps_min,
-                                                            in_temps_max,
-                                                            in_uacs,
-                                                            [out_temps_min[heat_out_idx]],
-                                                            [out_temps_max[heat_out_idx]],
-                                                            [out_uacs[heat_out_idx]])
-                                                        
+            layers_heat_out_uac_temp = calculate_energies_heatpump(unit,
+                                                                   sim_params,
+                                                                   copy(potential_energy_el),
+                                                                   copy(potentials_energies_heat_in),
+                                                                   [Inf],
+                                                                   max_usage_fraction,
+                                                                   in_temps_min,
+                                                                   in_temps_max,
+                                                                   in_uacs,
+                                                                   [out_temps_min[heat_out_idx]],
+                                                                   [out_temps_max[heat_out_idx]],
+                                                                   [out_uacs[heat_out_idx]])
+
             append!(layers_heat_out, layers_heat_out_temp)
             append!(layers_heat_out_temperature, layers_heat_out_temperature_temp)
             append!(layers_heat_out_uac, layers_heat_out_uac_temp)
@@ -561,18 +516,18 @@ function calculate_energies(
         layers_heat_in_uac,
         layers_heat_out,
         layers_heat_out_temperature,
-        layers_heat_out_uac  = calculate_energies_heatpump(unit,
-                                                           sim_params,
-                                                           potential_energy_el,
-                                                           potentials_energies_heat_in,
-                                                           potentials_energies_heat_out,
-                                                           max_usage_fraction,
-                                                           in_temps_min,
-                                                           in_temps_max,
-                                                           in_uacs,
-                                                           out_temps_min,
-                                                           out_temps_max,
-                                                           out_uacs)
+        layers_heat_out_uac = calculate_energies_heatpump(unit,
+                                                          sim_params,
+                                                          potential_energy_el,
+                                                          potentials_energies_heat_in,
+                                                          potentials_energies_heat_out,
+                                                          max_usage_fraction,
+                                                          in_temps_min,
+                                                          in_temps_max,
+                                                          in_uacs,
+                                                          out_temps_min,
+                                                          out_temps_max,
+                                                          out_uacs)
     end
 
     # if all chosen heat layers combined are not enough to meet minimum power fraction,
@@ -582,17 +537,16 @@ function calculate_energies(
         return false, (nothing, nothing, nothing)
     end
 
-    return true,                          
-           (layers_el_in,                 # 1
-           layers_heat_in,                # 2 
-           layers_heat_in_temperature,    # 3
-           layers_heat_in_uac,            # 4
-           layers_heat_out,               # 5
-           layers_heat_out_temperature,   # 6
-           layers_heat_out_uac,           # 7
-           heat_in_has_inf_energy,        # 8
-           heat_out_has_inf_energy        # 9 
-       )
+    return true,
+           (layers_el_in,                  # 1
+            layers_heat_in,                # 2 
+            layers_heat_in_temperature,    # 3
+            layers_heat_in_uac,            # 4
+            layers_heat_out,               # 5
+            layers_heat_out_temperature,   # 6
+            layers_heat_out_uac,           # 7
+            heat_in_has_inf_energy,        # 8
+            heat_out_has_inf_energy)       # 9
 end
 
 function potential(unit::HeatPump, sim_params::Dict{String,Any})
@@ -601,26 +555,20 @@ function potential(unit::HeatPump, sim_params::Dict{String,Any})
     if !success
         set_max_energies!(unit, 0.0, 0.0, 0.0)
     else
-        set_max_energies!(
-            unit,
-            energies[1],
-            energies[2],
-            energies[5],
-            energies[4],
-            energies[7],
-            energies[8],
-            energies[9]
-        )
-        set_temperature!(
-            unit.input_interfaces[unit.m_heat_in],
-            lowest(energies[3]),
-            nothing
-        )
-        set_temperature!(
-            unit.output_interfaces[unit.m_heat_out],
-            nothing,
-            highest(energies[6])
-        )
+        set_max_energies!(unit,
+                          energies[1],
+                          energies[2],
+                          energies[5],
+                          energies[4],
+                          energies[7],
+                          energies[8],
+                          energies[9])
+        set_temperature!(unit.input_interfaces[unit.m_heat_in],
+                         lowest(energies[3]),
+                         nothing)
+        set_temperature!(unit.output_interfaces[unit.m_heat_out],
+                         nothing,
+                         highest(energies[6]))
     end
 end
 
@@ -673,10 +621,10 @@ function reset(unit::HeatPump)
 end
 
 function output_values(unit::HeatPump)::Vector{String}
-    return [string(unit.m_el_in)*" IN", 
-            string(unit.m_heat_in)*" IN",
-            string(unit.m_heat_out)*" OUT",
-            "COP", 
+    return [string(unit.m_el_in) * " IN",
+            string(unit.m_heat_in) * " IN",
+            string(unit.m_heat_out) * " OUT",
+            "COP",
             "Losses",
             "MixingTemperature_Input",
             "MixingTemperature_Output"]

--- a/src/project_loading.jl
+++ b/src/project_loading.jl
@@ -1,7 +1,7 @@
 # this file contains functionality pertaining to loading a project's metadata and the
 # energy system components from the project config file, as well as constructing certain
 # helpful information data structures from the inputs in the config
-import JSON
+using JSON: JSON
 
 """
     read_JSON(filepath)
@@ -54,23 +54,19 @@ function load_components(config::Dict{String,Any}, sim_params::Dict{String,Any})
 
     # link inputs/outputs
     for (unit_key, entry) in pairs(config)
-        if (
-            String(entry["type"]) != "Bus"
+        if (String(entry["type"]) != "Bus"
             && haskey(entry, "output_refs")
-            && length(entry["output_refs"]) > 0
-        )
+            && length(entry["output_refs"]) > 0)
+            # end of condition
             others = Grouping(key => components[key] for key in entry["output_refs"])
             link_output_with(components[unit_key], others)
 
-        elseif (
-            String(entry["type"]) == "Bus"
-            && haskey(entry, "connections")
-            && length(entry["connections"]) > 0
-        )
-            others = Grouping(
-                key => components[key]
-                for key in entry["connections"]["output_order"]
-            )
+        elseif (String(entry["type"]) == "Bus"
+                && haskey(entry, "connections")
+                && length(entry["connections"]) > 0)
+            # end of condition
+            others = Grouping(key => components[key]
+                              for key in entry["connections"]["output_order"])
             link_output_with(components[unit_key], others)
         end
     end
@@ -83,22 +79,14 @@ function load_components(config::Dict{String,Any}, sim_params::Dict{String,Any})
         # registered here, compare automatic selection of component class
         for module_config in default(entry, "control_modules", [])
             if lowercase(module_config["name"]) === "economical_discharge"
-                push!(
-                    unit.controller.modules,
-                    EnergySystems.CM_EconomicalDischarge(
-                        module_config, components, sim_params
-                    )
-                )
+                push!(unit.controller.modules,
+                      EnergySystems.CM_EconomicalDischarge(module_config, components, sim_params))
             elseif lowercase(module_config["name"]) === "profile_limited"
-                push!(
-                    unit.controller.modules,
-                    EnergySystems.CM_ProfileLimited(module_config, components, sim_params)
-                )
+                push!(unit.controller.modules,
+                      EnergySystems.CM_ProfileLimited(module_config, components, sim_params))
             elseif lowercase(module_config["name"]) === "storage_driven"
-                push!(
-                    unit.controller.modules,
-                    EnergySystems.CM_StorageDriven(module_config, components, sim_params)
-                )
+                push!(unit.controller.modules,
+                      EnergySystems.CM_StorageDriven(module_config, components, sim_params))
             end
         end
     end
@@ -143,14 +131,10 @@ function reorder_interfaces_of_busses(components::Grouping)::Grouping
 
             # Get the permutation indices that would sort the 'source'/'target' field by
             # 'uac' order
-            output_perm_indices = sortperm([
-                output_order_dict[unit.output_interfaces[i].target.uac]
-                for i in 1:length(unit.output_interfaces)
-            ])
-            input_perm_indices = sortperm([
-                input_order_dict[unit.input_interfaces[i].source.uac]
-                for i in 1:length(unit.input_interfaces)
-            ])
+            output_perm_indices = sortperm([output_order_dict[unit.output_interfaces[i].target.uac]
+                                            for i in 1:length(unit.output_interfaces)])
+            input_perm_indices = sortperm([input_order_dict[unit.input_interfaces[i].source.uac]
+                                           for i in 1:length(unit.input_interfaces)])
 
             # Reorder the input and output interfaces using the permutation indices
             unit.output_interfaces = unit.output_interfaces[output_perm_indices]
@@ -170,7 +154,7 @@ time_step = 900 s
 start_timestamp = 0 s
 end_timestamp = 900 s
 """
-function get_timesteps(simulation_parameters::Dict{String, Any})
+function get_timesteps(simulation_parameters::Dict{String,Any})
     time_step = 900
     if "time_step_seconds" in keys(simulation_parameters)
         time_step = UInt(simulation_parameters["time_step_seconds"])

--- a/test/energy_systems/balance_and_distribution/bus_to_bus_distribution.jl
+++ b/test/energy_systems/balance_and_distribution/bus_to_bus_distribution.jl
@@ -30,25 +30,17 @@ function test_short_chain_distribution()
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                ],
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_BUS_02"],
             ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_BUS_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_DEM_02"
-                ],
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_DEM_02"],
             ),
         ),
     )
@@ -56,7 +48,7 @@ function test_short_chain_distribution()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -126,49 +118,33 @@ function test_long_chain_distribution()
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                ],
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_BUS_02"],
             ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_BUS_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_03",
-                    "TST_BUS_04"
-                ],
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_BUS_03",
+                                   "TST_BUS_04"],
             ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_BUS_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                ],
+                "input_order" => ["TST_BUS_02"],
+                "output_order" => ["TST_DEM_01"],
             ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_BUS_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                ],
+                "input_order" => ["TST_BUS_02"],
+                "output_order" => ["TST_DEM_02"],
             ),
         ),
     )
@@ -176,7 +152,7 @@ function test_long_chain_distribution()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/balance_and_distribution/many_plus_storage_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/many_plus_storage_to_one.jl
@@ -40,20 +40,14 @@ function test_many_plus_storage_to_one()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                    "TST_SRC_02",
-                    "TST_TES_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_TES_01",
-                ],
-                "energy_flow" => [
-                    [1,1],
-                    [1,1],
-                    [1,0],
-                ],
+                "input_order" => ["TST_SRC_01",
+                                  "TST_SRC_02",
+                                  "TST_TES_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_TES_01"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1],
+                                  [1, 0]],
             ),
         ),
     )
@@ -61,7 +55,7 @@ function test_many_plus_storage_to_one()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/balance_and_distribution/many_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/many_to_many.jl
@@ -54,24 +54,18 @@ function test_many_to_many()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                    "TST_TES_01",
-                    "TST_TES_02",
-                    "TST_SRC_02",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_DEM_02",
-                    "TST_TES_01",
-                    "TST_TES_02",
-                ],
-                "energy_flow" => [
-                    [1,1,1,1],
-                    [1,0,0,0],
-                    [0,1,0,0],
-                    [1,1,0,0],
-                ],
+                "input_order" => ["TST_SRC_01",
+                                  "TST_TES_01",
+                                  "TST_TES_02",
+                                  "TST_SRC_02"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_DEM_02",
+                                   "TST_TES_01",
+                                   "TST_TES_02"],
+                "energy_flow" => [[1, 1, 1, 1],
+                                  [1, 0, 0, 0],
+                                  [0, 1, 0, 0],
+                                  [1, 1, 0, 0]],
             ),
         ),
     )
@@ -79,7 +73,7 @@ function test_many_to_many()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -90,7 +84,6 @@ function test_many_to_many()
     bus = components["TST_BUS_TH_01"]
     storage_1 = components["TST_TES_01"]
     storage_2 = components["TST_TES_02"]
-
 
     # time step 1: source 1 is not enough to meet demands and storages are empty. source 2
     # fills the rest, but is not allowed to load storages

--- a/test/energy_systems/balance_and_distribution/many_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/many_to_one.jl
@@ -33,17 +33,11 @@ function test_many_to_one()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                    "TST_SRC_02",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ],
+                "input_order" => ["TST_SRC_01",
+                                  "TST_SRC_02"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
             ),
         ),
     )
@@ -51,7 +45,7 @@ function test_many_to_one()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/balance_and_distribution/one_bus_to_many_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_bus_to_many_bus.jl
@@ -18,43 +18,31 @@ function test_one_bus_to_many_bus()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BUS_03",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_TES_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_TES_01",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_TES_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_TES_01"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_TES_02",
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                    "TST_TES_02",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_TES_02"],
+                "output_order" => ["TST_DEM_02",
+                                   "TST_TES_02"],
+            ),
         ),
         "TST_TES_01" => Dict{String,Any}(
             "type" => "Storage",
@@ -89,7 +77,7 @@ function test_one_bus_to_many_bus()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -216,7 +204,6 @@ function test_one_bus_to_many_bus()
     @test bus_1.output_interfaces[1].sum_abs_change ≈ 2 * 100.0  # to bus_1
     @test bus_1.output_interfaces[2].sum_abs_change ≈ 0.0        # to bus_2
     @test bus_1.input_interfaces[1].sum_abs_change ≈ 2 * 100.0   # from src_1
-
 end
 
 @testset "one_bus_to_many_bus" begin

--- a/test/energy_systems/balance_and_distribution/one_bus_to_one_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_bus_to_one_bus.jl
@@ -17,26 +17,18 @@ function test_one_bus_to_one_bus()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_GRI_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_BUS_02"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_DEM_01"],
+            ),
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -50,7 +42,7 @@ function test_one_bus_to_one_bus()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -160,9 +152,8 @@ function test_one_bus_to_one_bus()
     @test bus_2.remainder ≈ 0.0
     @test bus_proxy.remainder ≈ 0.0
     @test grid.output_interfaces[grid.medium].balance ≈ 75.0
-    @test bus_proxy.balance_table[1,1] ≈ 75.0 # energy transferred from source 1 to sink 1 ...
-    @test bus_proxy.balance_table[1,2] ≈ 55.0 # with temperature of 55.0 °C
-
+    @test bus_proxy.balance_table[1, 1] ≈ 75.0 # energy transferred from source 1 to sink 1 ...
+    @test bus_proxy.balance_table[1, 2] ≈ 55.0 # with temperature of 55.0 °C
 
     EnergySystems.distribute!(bus_proxy)
     EnergySystems.distribute!(bus_2)
@@ -182,7 +173,6 @@ function test_one_bus_to_one_bus()
     @test bus_1.output_interfaces[1].sum_abs_change ≈ 150.0
     @test bus_2.input_interfaces[1].balance ≈ 0.0
     @test bus_2.input_interfaces[1].sum_abs_change ≈ 150.0
-
 end
 
 @testset "one_bus_to_one_bus" begin

--- a/test/energy_systems/balance_and_distribution/one_plus_storage_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/one_plus_storage_to_many.jl
@@ -40,19 +40,13 @@ function test_one_plus_storage_to_many()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                    "TST_TES_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_DEM_02",
-                    "TST_TES_01",
-                ],
-                "energy_flow" => [
-                    [1,1,1],
-                    [1,1,0],
-                ],
+                "input_order" => ["TST_SRC_01",
+                                  "TST_TES_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_DEM_02",
+                                   "TST_TES_01"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 1, 0]],
             ),
         ),
     )
@@ -60,7 +54,7 @@ function test_one_plus_storage_to_many()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -69,7 +63,6 @@ function test_one_plus_storage_to_many()
     demand_2 = components["TST_DEM_02"]
     bus = components["TST_BUS_TH_01"]
     storage = components["TST_TES_01"]
-
 
     # time step 1: the source can't cover the demands, the storage needs to fill the rest
 

--- a/test/energy_systems/balance_and_distribution/one_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_many.jl
@@ -33,16 +33,10 @@ function test_many_to_one()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_DEM_02",
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                ],
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_DEM_02"],
+                "energy_flow" => [[1, 1]],
             ),
         ),
     )
@@ -50,7 +44,7 @@ function test_many_to_one()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -58,7 +52,6 @@ function test_many_to_one()
     demand_1 = components["TST_DEM_01"]
     demand_2 = components["TST_DEM_02"]
     bus = components["TST_BUS_TH_01"]
-
 
     EnergySystems.reset(demand_1)
     EnergySystems.reset(demand_2)
@@ -84,7 +77,7 @@ function test_many_to_one()
 
     exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0            # is always zero in exchange of bus
-    @test EnergySystems.energy_potential(exchanges) ≈ -1000.0 
+    @test EnergySystems.energy_potential(exchanges) ≈ -1000.0
     @test EnergySystems.temp_min_highest(exchanges) === 54.0
 
     exchanges = EnergySystems.balance_on(bus.output_interfaces[1], bus)
@@ -100,7 +93,7 @@ function test_many_to_one()
 
     exchanges = EnergySystems.balance_on(bus.output_interfaces[2], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0            # is always zero in exchange of bus
-    @test EnergySystems.energy_potential(exchanges) ≈ 500.0 
+    @test EnergySystems.energy_potential(exchanges) ≈ 500.0
     @test EnergySystems.temp_min_highest(exchanges) === nothing
     @test EnergySystems.temp_max_highest(exchanges) === 55.0
 
@@ -111,7 +104,7 @@ function test_many_to_one()
 
     exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0            # is always zero in exchange of bus
-    @test EnergySystems.energy_potential(exchanges) ≈ -1000.0 
+    @test EnergySystems.energy_potential(exchanges) ≈ -1000.0
     @test EnergySystems.temp_min_highest(exchanges) === 54.0
 
     EnergySystems.process(bus, simulation_parameters)
@@ -133,7 +126,6 @@ function test_many_to_one()
 
     @test source.output_interfaces[source.medium].balance == 0.0
     @test source.output_interfaces[source.medium].temperature_max == 55.0
-
 end
 
 @testset "many_to_one" begin

--- a/test/energy_systems/balance_and_distribution/one_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_one.jl
@@ -26,7 +26,7 @@ function test_one_to_one_grid()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -60,7 +60,6 @@ end
     test_one_to_one_grid()
 end
 
-
 function test_one_to_one_bounded_source()
     components_config = Dict{String,Any}(
         "TST_SRC_01" => Dict{String,Any}(
@@ -68,7 +67,7 @@ function test_one_to_one_bounded_source()
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_DEM_01"],
             "constant_temperature" => 50,
-            "constant_power" => 4000
+            "constant_power" => 4000,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -82,7 +81,7 @@ function test_one_to_one_bounded_source()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/balance_and_distribution/one_to_one_via_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_one_via_bus.jl
@@ -25,15 +25,9 @@ function test_one_to_one_via_bus()
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                ],
-                "energy_flow" => [
-                    [1],
-                ],
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1]],
             ),
         ),
     )
@@ -41,7 +35,7 @@ function test_one_to_one_via_bus()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/energy_system_from_storage.jl
+++ b/test/energy_systems/energy_system_from_storage.jl
@@ -14,30 +14,24 @@ function test_run_energy_system_from_storage()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_BFT_01"
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_BFT_01"],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
             "load" => 30000,
-            "high_temperature" => 35.0
+            "high_temperature" => 35.0,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -49,12 +43,12 @@ function test_run_energy_system_from_storage()
             "type" => "HeatPump",
             "output_refs" => ["TST_DEM_01"],
             "control_parameters" => Dict{String,Any}(
-                "unload_storages m_e_ac_230v" => true
+                "unload_storages m_e_ac_230v" => true,
             ),
             "m_el_in" => "m_e_ac_230v",
             "power_th" => 12000,
             "constant_cop" => 3.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
     )
 
@@ -62,7 +56,7 @@ function test_run_energy_system_from_storage()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -83,7 +77,7 @@ function test_run_energy_system_from_storage()
     EnergySystems.control(lheat_storage, components, simulation_parameters)
     EnergySystems.control(lheat_bus, components, simulation_parameters)
 
-    hheat_demand.constant_demand = 800*4
+    hheat_demand.constant_demand = 800 * 4
     hheat_demand.constant_temperature = 45.0
     EnergySystems.control(hheat_demand, components, simulation_parameters)
 
@@ -103,22 +97,22 @@ function test_run_energy_system_from_storage()
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 1600
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].temperature_min ≈ 45.0
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].temperature_max === nothing
-    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -800/3
+    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -800 / 3
     @test heat_pump.input_interfaces[heat_pump.m_el_in].temperature_min === nothing
-    @test heat_pump.input_interfaces[heat_pump.m_heat_in].balance ≈ -800*2/3
+    @test heat_pump.input_interfaces[heat_pump.m_heat_in].balance ≈ -800 * 2 / 3
     @test heat_pump.input_interfaces[heat_pump.m_heat_in].temperature_min === nothing
 
     EnergySystems.process(lheat_bus, simulation_parameters)
     EnergySystems.process(lheat_storage, simulation_parameters)
     EnergySystems.load(lheat_storage, simulation_parameters)
 
-    @test lheat_storage.output_interfaces[lheat_storage.medium].balance ≈ 800*2/3
-    @test lheat_storage.output_interfaces[lheat_storage.medium].sum_abs_change ≈ 800*2/3
+    @test lheat_storage.output_interfaces[lheat_storage.medium].balance ≈ 800 * 2 / 3
+    @test lheat_storage.output_interfaces[lheat_storage.medium].sum_abs_change ≈ 800 * 2 / 3
     @test lheat_storage.output_interfaces[lheat_storage.medium].temperature_max ≈ 35.0
 
     EnergySystems.process(power_grid, simulation_parameters)
     @test power_grid.output_interfaces[power_grid.medium].balance ≈ 0
-    @test power_grid.output_interfaces[power_grid.medium].sum_abs_change ≈ 2*800/3
+    @test power_grid.output_interfaces[power_grid.medium].sum_abs_change ≈ 2 * 800 / 3
     @test power_grid.output_interfaces[power_grid.medium].temperature_max === nothing
 
     # second step: storage is nearly empty, operation of heatpump is limited
@@ -134,7 +128,7 @@ function test_run_energy_system_from_storage()
     lheat_storage.load = 100.0
     EnergySystems.control(lheat_storage, components, simulation_parameters)
 
-    hheat_demand.constant_demand = 800*4
+    hheat_demand.constant_demand = 800 * 4
     hheat_demand.constant_temperature = 45.0
     EnergySystems.control(hheat_demand, components, simulation_parameters)
 
@@ -150,11 +144,11 @@ function test_run_energy_system_from_storage()
     @test EnergySystems.temp_max_highest(exchanges) === 35.0
 
     EnergySystems.process(heat_pump, simulation_parameters)
-    @test heat_pump.output_interfaces[heat_pump.m_heat_out].balance ≈ -800 + 100*3/2
-    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 800+100*3/2
+    @test heat_pump.output_interfaces[heat_pump.m_heat_out].balance ≈ -800 + 100 * 3 / 2
+    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 800 + 100 * 3 / 2
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].temperature_min ≈ 45.0
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].temperature_max === nothing
-    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -(100*3/2)/3
+    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -(100 * 3 / 2) / 3
     @test heat_pump.input_interfaces[heat_pump.m_el_in].temperature_min === nothing
     @test heat_pump.input_interfaces[heat_pump.m_heat_in].balance ≈ -100
     @test heat_pump.input_interfaces[heat_pump.m_heat_in].temperature_min === nothing
@@ -169,9 +163,8 @@ function test_run_energy_system_from_storage()
 
     EnergySystems.process(power_grid, simulation_parameters)
     @test power_grid.output_interfaces[power_grid.medium].balance ≈ 0
-    @test power_grid.output_interfaces[power_grid.medium].sum_abs_change ≈ 2*(100*3/2)/3
+    @test power_grid.output_interfaces[power_grid.medium].sum_abs_change ≈ 2 * (100 * 3 / 2) / 3
     @test power_grid.output_interfaces[power_grid.medium].temperature_max === nothing
-
 end
 
 function test_run_energy_system_from_storage_denied()
@@ -182,30 +175,24 @@ function test_run_energy_system_from_storage_denied()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_BFT_01"
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_BFT_01"],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
             "load" => 30000,
-            "high_temperature" => 35
+            "high_temperature" => 35,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -217,12 +204,12 @@ function test_run_energy_system_from_storage_denied()
             "type" => "HeatPump",
             "output_refs" => ["TST_DEM_01"],
             "control_parameters" => Dict{String,Any}(
-                "unload_storages m_h_w_lt1" => false
+                "unload_storages m_h_w_lt1" => false,
             ),
             "m_el_in" => "m_e_ac_230v",
             "power_th" => 12000,
             "constant_cop" => 3.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
     )
 
@@ -230,7 +217,7 @@ function test_run_energy_system_from_storage_denied()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -252,7 +239,7 @@ function test_run_energy_system_from_storage_denied()
     EnergySystems.control(lheat_storage, components, simulation_parameters)
     EnergySystems.control(lheat_bus, components, simulation_parameters)
 
-    hheat_demand.constant_demand = 800*4
+    hheat_demand.constant_demand = 800 * 4
     hheat_demand.constant_temperature = 45.0
     EnergySystems.control(hheat_demand, components, simulation_parameters)
 
@@ -289,7 +276,6 @@ function test_run_energy_system_from_storage_denied()
     @test power_grid.output_interfaces[power_grid.medium].balance ≈ 0
     @test power_grid.output_interfaces[power_grid.medium].sum_abs_change ≈ 0.0
     @test power_grid.output_interfaces[power_grid.medium].temperature_max === nothing
-
 end
 
 @testset "run_energy_system_from_storage" begin

--- a/test/energy_systems/gasboiler_demand_driven_with_bus.jl
+++ b/test/energy_systems/gasboiler_demand_driven_with_bus.jl
@@ -7,22 +7,22 @@ using Resie.Profiles
 EnergySystems.set_timestep(900)
 
 function test_gasboiler_demand_driven_with_bus()
-   components_config = Dict{String,Any}(
+    components_config = Dict{String,Any}(
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_GB_01"],
-                "output_order" => ["TST_DEM_01"]
-            )
+                "output_order" => ["TST_DEM_01"],
+            ),
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -43,7 +43,7 @@ function test_gasboiler_demand_driven_with_bus()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -77,7 +77,7 @@ function test_gasboiler_demand_driven_with_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -12000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -12000 / 4
 
     # no processing so far, balance is zero, energy_potential is zero
     exchanges = EnergySystems.balance_on(demand.input_interfaces[bus.medium], bus)
@@ -85,28 +85,28 @@ function test_gasboiler_demand_driven_with_bus()
     @test EnergySystems.energy_potential(exchanges) ≈ Inf
 
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -12000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -12000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min ≈ 85
 
     # demand was processed --> energy_potential shows the possible energy to deliver, balance is zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0  # balance of bus is always zero
-    @test EnergySystems.energy_potential(exchanges) ≈ -12000.0/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -12000.0 / 4
 
     EnergySystems.process(bus, simulation_parameters)
     EnergySystems.process(gasboiler, simulation_parameters)
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 12000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 12000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000 / 4
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*12000/4
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 12000 / 4
 
     EnergySystems.distribute!(bus)
     @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 0
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2*12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2 * 12000 / 4
     @test demand.input_interfaces[demand.medium].balance ≈ 0
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2*12000/4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2 * 12000 / 4
     @test bus.remainder ≈ 0
 
     # second step: demand is above max power of GasBoiler
@@ -131,7 +131,7 @@ function test_gasboiler_demand_driven_with_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -15000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -15000 / 4
 
     # no processing so far, balance is zero, energy_potential is zero
     exchanges = EnergySystems.balance_on(demand.input_interfaces[bus.medium], bus)
@@ -139,29 +139,29 @@ function test_gasboiler_demand_driven_with_bus()
     @test EnergySystems.energy_potential(exchanges) ≈ Inf
 
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -15000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -15000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min ≈ 85
 
     # demand was processed --> energy_potential shows the possible energy to deliver, balance is zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0  # balance of bus is always zero
-    @test EnergySystems.energy_potential(exchanges) ≈ -15000.0/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -15000.0 / 4
 
     EnergySystems.process(bus, simulation_parameters)
     EnergySystems.process(gasboiler, simulation_parameters)
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 12000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 12000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000 / 4
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*12000/4
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 12000 / 4
 
     EnergySystems.distribute!(bus)
     @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 0
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2*12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2 * 12000 / 4
     @test demand.input_interfaces[demand.medium].balance ≈ 0 #-15000/4 + 12000/4   # is Bus intended to supply all demand???
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 15000/4 + 15000/4
-    @test bus.remainder ≈ -15000/4 + 12000/4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 15000 / 4 + 15000 / 4
+    @test bus.remainder ≈ -15000 / 4 + 12000 / 4
 
     # third step: demand is below max power of GasBoiler
 
@@ -185,37 +185,36 @@ function test_gasboiler_demand_driven_with_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -10000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -10000 / 4
 
     # no processing so far, balance is zero, energy_potential is zero
     exchanges = EnergySystems.balance_on(demand.input_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0
     @test EnergySystems.energy_potential(exchanges) ≈ Inf
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -10000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -10000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min ≈ 85
 
     # demand was processed --> energy_potential shows the possible energy to deliver, balance is zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[bus.medium], bus)
     @test EnergySystems.balance(exchanges) ≈ 0.0  # balance of bus is always zero
-    @test EnergySystems.energy_potential(exchanges) ≈ -10000.0/4
+    @test EnergySystems.energy_potential(exchanges) ≈ -10000.0 / 4
 
     EnergySystems.process(bus, simulation_parameters)
     EnergySystems.process(gasboiler, simulation_parameters)
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 10000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -10000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 10000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -10000 / 4
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*10000/4
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 10000 / 4
 
     EnergySystems.distribute!(bus)
     @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 0
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2*10000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2 * 10000 / 4
     @test demand.input_interfaces[demand.medium].balance ≈ 0
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2*10000/4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2 * 10000 / 4
     @test bus.remainder ≈ 0
-
 end
 
 function test_gasboiler_demand_driven_without_bus()
@@ -226,7 +225,7 @@ function test_gasboiler_demand_driven_without_bus()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -247,7 +246,7 @@ function test_gasboiler_demand_driven_without_bus()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -279,7 +278,7 @@ function test_gasboiler_demand_driven_without_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ 12000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ 12000 / 4
 
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
@@ -287,29 +286,29 @@ function test_gasboiler_demand_driven_without_bus()
     @test EnergySystems.energy_potential(exchanges) == -Inf
 
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -12000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -12000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min == 85
 
     # demand was processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -12000/4
+    @test EnergySystems.balance(exchanges) ≈ -12000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(gasboiler, simulation_parameters)
     @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 0
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2*12000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2 * 12000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000 / 4
     @test demand.input_interfaces[demand.medium].balance ≈ 0
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2*12000/4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2 * 12000 / 4
 
     # demand and gasboiler were processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -12000/4
+    @test EnergySystems.balance(exchanges) ≈ -12000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*12000/4
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 12000 / 4
 
     # second step: demand is above max power of GasBoiler
 
@@ -332,7 +331,7 @@ function test_gasboiler_demand_driven_without_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ 15000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ 15000 / 4
 
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
@@ -340,29 +339,29 @@ function test_gasboiler_demand_driven_without_bus()
     @test EnergySystems.energy_potential(exchanges) == -Inf
 
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -15000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -15000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min == 85
 
     # demand was processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -15000/4
+    @test EnergySystems.balance(exchanges) ≈ -15000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(gasboiler, simulation_parameters)
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ -15000/4 + 12000/4
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 12000/4 + 15000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000/4
-    @test demand.input_interfaces[demand.medium].balance ≈ -15000/4 + 12000/4
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 15000/4 + 12000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ -15000 / 4 + 12000 / 4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 12000 / 4 + 15000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -12000 / 4
+    @test demand.input_interfaces[demand.medium].balance ≈ -15000 / 4 + 12000 / 4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 15000 / 4 + 12000 / 4
 
     # demand and gasboiler were processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -12000/4
+    @test EnergySystems.balance(exchanges) ≈ -12000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*12000/4
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 12000 / 4
 
     # third step: demand is below max power of GasBoiler
 
@@ -385,7 +384,7 @@ function test_gasboiler_demand_driven_without_bus()
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ 10000/4
+    @test EnergySystems.energy_potential(exchanges) ≈ 10000 / 4
 
     # no processing so far, balance is zero, energy_potential is non-zero
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
@@ -393,32 +392,30 @@ function test_gasboiler_demand_driven_without_bus()
     @test EnergySystems.energy_potential(exchanges) == -Inf
 
     EnergySystems.process(demand, simulation_parameters)
-    @test demand.input_interfaces[demand.medium].balance ≈ -10000/4
+    @test demand.input_interfaces[demand.medium].balance ≈ -10000 / 4
     @test demand.input_interfaces[demand.medium].temperature_min == 85
 
     # demand was processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.output_interfaces[gasboiler.m_heat_out], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -10000/4
+    @test EnergySystems.balance(exchanges) ≈ -10000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(gasboiler, simulation_parameters)
     @test gasboiler.output_interfaces[gasboiler.m_heat_out].balance ≈ 0
-    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2*10000/4
-    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -10000/4
+    @test gasboiler.output_interfaces[gasboiler.m_heat_out].sum_abs_change ≈ 2 * 10000 / 4
+    @test gasboiler.input_interfaces[gasboiler.m_fuel_in].balance ≈ -10000 / 4
     @test demand.input_interfaces[demand.medium].balance ≈ 0
-    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2*10000/4
+    @test demand.input_interfaces[demand.medium].sum_abs_change ≈ 2 * 10000 / 4
 
     # demand and gasboiler were processed --> energy_potential should be zero, but not the balance
     exchanges = EnergySystems.balance_on(gasboiler.input_interfaces[gasboiler.m_fuel_in], gasboiler)
-    @test EnergySystems.balance(exchanges) ≈ -10000/4
+    @test EnergySystems.balance(exchanges) ≈ -10000 / 4
     @test EnergySystems.energy_potential(exchanges) ≈ 0.0
 
     EnergySystems.process(grid, simulation_parameters)
     @test grid.output_interfaces[grid.medium].balance ≈ 0
-    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2*10000/4
-
+    @test grid.output_interfaces[grid.medium].sum_abs_change ≈ 2 * 10000 / 4
 end
-
 
 @testset "test_gasboiler_demand_driven_with_bus" begin
     test_gasboiler_demand_driven_with_bus()

--- a/test/energy_systems/multiple_transformer_limited.jl
+++ b/test/energy_systems/multiple_transformer_limited.jl
@@ -14,32 +14,32 @@ function test_multiple_transformer_with_limitations()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_DEM_H2_01" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_c_g_h2",
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_h2.prf",
-            "scale" => 3000
+            "scale" => 3000,
         ),
         "TST_GRI_O2_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_o2",
             "output_refs" => [],
-            "is_source" => false
+            "is_source" => false,
         ),
         "TST_GRI_el_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
             "output_refs" => ["TST_ELY_01"],
-            "is_source" => true
+            "is_source" => true,
         ),
         "TST_GRI_el_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
             "output_refs" => ["TST_HP_01"],
-            "is_source" => true
+            "is_source" => true,
         ),
         "TST_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
@@ -66,7 +66,7 @@ function test_multiple_transformer_with_limitations()
             "output_refs" => ["TST_DEM_heat_01"],
             "power_th" => 2240,
             "constant_cop" => 3.5,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
     )
 
@@ -74,7 +74,7 @@ function test_multiple_transformer_with_limitations()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -103,56 +103,57 @@ function test_multiple_transformer_with_limitations()
 
     EnergySystems.process(demand_heat, simulation_parameters)
     EnergySystems.process(demand_h2, simulation_parameters)
-    @test demand_heat.input_interfaces[demand_heat.medium].balance ≈ -2240/4
-    @test demand_h2.input_interfaces[demand_h2.medium].balance ≈ -2400/4
+    @test demand_heat.input_interfaces[demand_heat.medium].balance ≈ -2240 / 4
+    @test demand_h2.input_interfaces[demand_h2.medium].balance ≈ -2400 / 4
 
     EnergySystems.potential(heat_pump, simulation_parameters)
-    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_heat_in].max_energy) ≈ 2240/4 * ((3.5-1)/3.5)
-    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_el_in].max_energy) ≈ 2240/4 / 3.5
-    @test EnergySystems.get_max_energy(heat_pump.output_interfaces[heat_pump.m_heat_out].max_energy) ≈ 2240/4
+    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_heat_in].max_energy) ≈
+          2240 / 4 * ((3.5 - 1) / 3.5)
+    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_el_in].max_energy) ≈ 2240 / 4 / 3.5
+    @test EnergySystems.get_max_energy(heat_pump.output_interfaces[heat_pump.m_heat_out].max_energy) ≈ 2240 / 4
 
     exchanges = EnergySystems.balance_on(heat_pump.input_interfaces[heat_pump.m_heat_in], heat_pump)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ -2400 / 4 / 0.6 * 0.4
 
     EnergySystems.potential(electrolyser, simulation_parameters)
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_heat_ht_out].max_energy) ≈ 2400/4/0.6*0.4
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_h2_out].max_energy) ≈ 2400/4
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_o2_out].max_energy) ≈ 2400/4
-    @test EnergySystems.get_max_energy(electrolyser.input_interfaces[electrolyser.m_el_in].max_energy) ≈ 2400/4/0.6
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_heat_ht_out].max_energy) ≈
+          2400 / 4 / 0.6 * 0.4
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_h2_out].max_energy) ≈ 2400 / 4
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_o2_out].max_energy) ≈ 2400 / 4
+    @test EnergySystems.get_max_energy(electrolyser.input_interfaces[electrolyser.m_el_in].max_energy) ≈ 2400 / 4 / 0.6
 
     exchanges = EnergySystems.balance_on(heat_pump.input_interfaces[heat_pump.m_heat_in], heat_pump)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ -2400 / 4 / 0.6 * 0.4
 
     exchanges = EnergySystems.balance_on(electrolyser.output_interfaces[electrolyser.m_heat_ht_out], electrolyser)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ 2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ 2400 / 4 / 0.6 * 0.4
 
     EnergySystems.process(electrolyser, simulation_parameters)
-    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].balance ≈ 1600/4
-    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].sum_abs_change ≈ 1600/4
+    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].balance ≈ 1600 / 4
+    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].sum_abs_change ≈ 1600 / 4
     @test electrolyser.output_interfaces[electrolyser.m_h2_out].balance ≈ 0
-    @test electrolyser.output_interfaces[electrolyser.m_h2_out].sum_abs_change ≈ 2*2400/4
-    @test electrolyser.output_interfaces[electrolyser.m_o2_out].balance ≈ 2400/4
-    @test electrolyser.input_interfaces[electrolyser.m_el_in].balance ≈ -4000/4
+    @test electrolyser.output_interfaces[electrolyser.m_h2_out].sum_abs_change ≈ 2 * 2400 / 4
+    @test electrolyser.output_interfaces[electrolyser.m_o2_out].balance ≈ 2400 / 4
+    @test electrolyser.input_interfaces[electrolyser.m_el_in].balance ≈ -4000 / 4
 
     EnergySystems.process(heat_pump, simulation_parameters)
     @test heat_pump.output_interfaces[heat_pump.m_heat_out].balance ≈ 0
-    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 2*2240/4
-    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -640/4
+    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 2 * 2240 / 4
+    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -640 / 4
     @test heat_pump.input_interfaces[heat_pump.m_heat_in].balance ≈ 0
 
     EnergySystems.process(grid_el1, simulation_parameters)
     EnergySystems.process(grid_el2, simulation_parameters)
     EnergySystems.process(grid_o2, simulation_parameters)
     @test grid_o2.input_interfaces[grid_o2.medium].balance ≈ 0
-    @test grid_o2.input_interfaces[grid_o2.medium].sum_abs_change ≈ 2*2400/4
+    @test grid_o2.input_interfaces[grid_o2.medium].sum_abs_change ≈ 2 * 2400 / 4
     @test grid_el1.output_interfaces[grid_el1.medium].balance ≈ 0
-    @test grid_el1.output_interfaces[grid_el1.medium].sum_abs_change ≈ 2*4000/4
+    @test grid_el1.output_interfaces[grid_el1.medium].sum_abs_change ≈ 2 * 4000 / 4
     @test grid_el2.output_interfaces[grid_el2.medium].balance ≈ 0
-    @test grid_el2.output_interfaces[grid_el2.medium].sum_abs_change ≈ 2*640/4
-
+    @test grid_el2.output_interfaces[grid_el2.medium].sum_abs_change ≈ 2 * 640 / 4
 
     # second timestep: demand of h2 is limiting the state of the electrolyser. Therefore, the demand of waste heat in
     # the interface between electrolyser and heat pump can not be met. As a result, the state of the heat pump
@@ -169,7 +170,7 @@ function test_multiple_transformer_with_limitations()
         EnergySystems.reset(unit)
     end
 
-    demand_h2.constant_demand = 0.5*2400  # reducing h2 demand by half
+    demand_h2.constant_demand = 0.5 * 2400  # reducing h2 demand by half
     demand_heat.constant_demand = 2240  # same heat demand as bevore
     EnergySystems.control(demand_heat, components, simulation_parameters)
     EnergySystems.control(demand_h2, components, simulation_parameters)
@@ -181,60 +182,63 @@ function test_multiple_transformer_with_limitations()
 
     EnergySystems.process(demand_heat, simulation_parameters)
     EnergySystems.process(demand_h2, simulation_parameters)
-    @test demand_heat.input_interfaces[demand_heat.medium].balance ≈ -2240/4
-    @test demand_h2.input_interfaces[demand_h2.medium].balance ≈ -0.5*2400/4
+    @test demand_heat.input_interfaces[demand_heat.medium].balance ≈ -2240 / 4
+    @test demand_h2.input_interfaces[demand_h2.medium].balance ≈ -0.5 * 2400 / 4
 
     EnergySystems.potential(heat_pump, simulation_parameters)
-    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_heat_in].max_energy) ≈ 2240/4 * ((3.5-1)/3.5)
-    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_el_in].max_energy) ≈ 2240/4 / 3.5
-    @test EnergySystems.get_max_energy(heat_pump.output_interfaces[heat_pump.m_heat_out].max_energy) ≈ 2240/4
+    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_heat_in].max_energy) ≈
+          2240 / 4 * ((3.5 - 1) / 3.5)
+    @test EnergySystems.get_max_energy(heat_pump.input_interfaces[heat_pump.m_el_in].max_energy) ≈ 2240 / 4 / 3.5
+    @test EnergySystems.get_max_energy(heat_pump.output_interfaces[heat_pump.m_heat_out].max_energy) ≈ 2240 / 4
 
     exchanges = EnergySystems.balance_on(heat_pump.input_interfaces[heat_pump.m_heat_in], heat_pump)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ -2400 / 4 / 0.6 * 0.4
 
     EnergySystems.potential(electrolyser, simulation_parameters)
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_heat_ht_out].max_energy) ≈ 0.5*2400/4/0.6*0.4
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_h2_out].max_energy) ≈ 0.5*2400/4
-    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_o2_out].max_energy) ≈ 0.5*2400/4
-    @test EnergySystems.get_max_energy(electrolyser.input_interfaces[electrolyser.m_el_in].max_energy) ≈ 0.5*2400/4/0.6
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_heat_ht_out].max_energy) ≈
+          0.5 * 2400 / 4 / 0.6 * 0.4
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_h2_out].max_energy) ≈
+          0.5 * 2400 / 4
+    @test EnergySystems.get_max_energy(electrolyser.output_interfaces[electrolyser.m_o2_out].max_energy) ≈
+          0.5 * 2400 / 4
+    @test EnergySystems.get_max_energy(electrolyser.input_interfaces[electrolyser.m_el_in].max_energy) ≈
+          0.5 * 2400 / 4 / 0.6
 
     exchanges = EnergySystems.balance_on(heat_pump.input_interfaces[heat_pump.m_heat_in], heat_pump)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ -0.5*2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ -0.5 * 2400 / 4 / 0.6 * 0.4
 
     exchanges = EnergySystems.balance_on(electrolyser.output_interfaces[electrolyser.m_heat_ht_out], electrolyser)
     @test EnergySystems.balance(exchanges) ≈ 0.0
-    @test EnergySystems.energy_potential(exchanges) ≈ 0.5*2400/4/0.6*0.4
+    @test EnergySystems.energy_potential(exchanges) ≈ 0.5 * 2400 / 4 / 0.6 * 0.4
 
     EnergySystems.process(electrolyser, simulation_parameters)
     EnergySystems.process(heat_pump, simulation_parameters)
 
-    @test heat_pump.output_interfaces[heat_pump.m_heat_out].balance ≈ -0.5*2240/4
-    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 560+560/2
-    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -0.5*640/4
+    @test heat_pump.output_interfaces[heat_pump.m_heat_out].balance ≈ -0.5 * 2240 / 4
+    @test heat_pump.output_interfaces[heat_pump.m_heat_out].sum_abs_change ≈ 560 + 560 / 2
+    @test heat_pump.input_interfaces[heat_pump.m_el_in].balance ≈ -0.5 * 640 / 4
     @test heat_pump.input_interfaces[heat_pump.m_heat_in].balance ≈ 0  # process of electrolyser already done
-    @test heat_pump.input_interfaces[heat_pump.m_heat_in].sum_abs_change ≈ 0.5*2*1600/4 # 200 are transferred between ely and hp
+    @test heat_pump.input_interfaces[heat_pump.m_heat_in].sum_abs_change ≈ 0.5 * 2 * 1600 / 4 # 200 are transferred between ely and hp
 
     @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].balance ≈ 0 #actually the same as two test above
-    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].sum_abs_change ≈ 0.5*2*1600/4  #actually the same as two test above
+    @test electrolyser.output_interfaces[electrolyser.m_heat_ht_out].sum_abs_change ≈ 0.5 * 2 * 1600 / 4  #actually the same as two test above
 
     @test electrolyser.output_interfaces[electrolyser.m_h2_out].balance ≈ 0
-    @test electrolyser.output_interfaces[electrolyser.m_h2_out].sum_abs_change ≈ 2*0.5*2400/4
-    @test electrolyser.output_interfaces[electrolyser.m_o2_out].balance ≈ 0.5*2400/4
-    @test electrolyser.input_interfaces[electrolyser.m_el_in].balance ≈ -0.5*4000/4
+    @test electrolyser.output_interfaces[electrolyser.m_h2_out].sum_abs_change ≈ 2 * 0.5 * 2400 / 4
+    @test electrolyser.output_interfaces[electrolyser.m_o2_out].balance ≈ 0.5 * 2400 / 4
+    @test electrolyser.input_interfaces[electrolyser.m_el_in].balance ≈ -0.5 * 4000 / 4
 
     EnergySystems.process(grid_el1, simulation_parameters)
     EnergySystems.process(grid_el2, simulation_parameters)
     EnergySystems.process(grid_o2, simulation_parameters)
     @test grid_o2.input_interfaces[grid_o2.medium].balance ≈ 0
-    @test grid_o2.input_interfaces[grid_o2.medium].sum_abs_change ≈ 2*0.5*2400/4
+    @test grid_o2.input_interfaces[grid_o2.medium].sum_abs_change ≈ 2 * 0.5 * 2400 / 4
     @test grid_el1.output_interfaces[grid_el1.medium].balance ≈ 0
-    @test grid_el1.output_interfaces[grid_el1.medium].sum_abs_change ≈ 2*0.5*4000/4
+    @test grid_el1.output_interfaces[grid_el1.medium].sum_abs_change ≈ 2 * 0.5 * 4000 / 4
     @test grid_el2.output_interfaces[grid_el2.medium].balance ≈ 0
-    @test grid_el2.output_interfaces[grid_el2.medium].sum_abs_change ≈ 2*0.5*640/4
-
-
+    @test grid_el2.output_interfaces[grid_el2.medium].sum_abs_change ≈ 2 * 0.5 * 640 / 4
 end
 
 @testset "multiple_transformer_with_limitations" begin

--- a/test/energy_systems/plr_dependent_efficiency.jl
+++ b/test/energy_systems/plr_dependent_efficiency.jl
@@ -69,7 +69,7 @@ function test_inverse_efficiency()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => eps
+        "epsilon" => eps,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -103,7 +103,7 @@ function test_gas_boiler_demand_driven_plrd()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -120,7 +120,7 @@ function test_gas_boiler_demand_driven_plrd()
         EnergySystems.reset(unit)
     end
 
-    expected_efficiency = 1.0 
+    expected_efficiency = 1.0
 
     EnergySystems.control(demand, components, simulation_parameters)
     EnergySystems.control(gasboiler, components, simulation_parameters)
@@ -197,9 +197,9 @@ function test_gas_boiler_supply_driven_plrd()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     gasboiler = components["TST_GB_01"]
     grid = components["TST_GRI_01"]
@@ -221,7 +221,7 @@ function test_gas_boiler_supply_driven_plrd()
     grid.output_interfaces[grid.medium].max_energy.max_energy[1] = grid.supply
     EnergySystems.control(gasboiler, components, simulation_parameters)
     EnergySystems.control(demand, components, simulation_parameters)
-    demand.input_interfaces[demand.medium].max_energy.max_energy[1] =  1000 * 10.0
+    demand.input_interfaces[demand.medium].max_energy.max_energy[1] = 1000 * 10.0
     demand.max_energy = 1000 * 10
 
     EnergySystems.process(grid, simulation_parameters)
@@ -245,7 +245,7 @@ function test_gas_boiler_supply_driven_plrd()
 
     EnergySystems.control(grid, components, simulation_parameters)
     grid.supply = 500 / expected_efficiency
-    grid.output_interfaces[grid.medium].max_energy.max_energy[1] =  grid.supply
+    grid.output_interfaces[grid.medium].max_energy.max_energy[1] = grid.supply
     EnergySystems.control(gasboiler, components, simulation_parameters)
     EnergySystems.control(demand, components, simulation_parameters)
     demand.input_interfaces[demand.medium].max_energy.max_energy[1] = 500 * 10.0
@@ -293,24 +293,22 @@ function test_CHPP_el_eff_plrd()
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_DEM_01",
-                "TST_GRO_01",
-            ],
+            "output_refs" => ["TST_DEM_01",
+                              "TST_GRO_01"],
             "power_el" => 5000,
             "linear_interface" => "el_out",
             "min_power_fraction" => 0.1,
             "efficiency_fuel_in" => "const:2.5",
             "efficiency_heat_out" => "pwlin:0.8,0.9,1.0,0.8",
             "efficiency_el_out" => "const:1.0",
-            "nr_discretization_steps" => 25
+            "nr_discretization_steps" => 25,
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -421,24 +419,22 @@ function test_electrolyser_dispatch_units()
         ),
         "TST_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_DEM_01",
-                "TST_GRO_01",
-                "TST_GRO_02"
-            ],
+            "output_refs" => ["TST_DEM_01",
+                              "TST_GRO_01",
+                              "TST_GRO_02"],
             "power_el" => 4000,
             "heat_lt_is_usable" => false,
             "nr_switchable_units" => 4,
             "dispatch_strategy" => "equal_with_mpf",
             "min_power_fraction_total" => 0.3,
-            "min_power_fraction" => 0.4
+            "min_power_fraction" => 0.4,
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/energy_systems/storage_loading_switch.jl
+++ b/test/energy_systems/storage_loading_switch.jl
@@ -23,56 +23,42 @@ function test_primary_producer_can_load_storage()
         "TST_GBO_01" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "storage_driven",
-                    "high_threshold" => 0.5,
-                    "low_threshold" => 0.1,
-                    "storage_uac" => "TST_BFT_01"
-                )
-            ],
+            "output_refs" => ["TST_BUS_01"],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "storage_driven",
+                                      "high_threshold" => 0.5,
+                                      "low_threshold" => 0.1,
+                                      "storage_uac" => "TST_BFT_01",
+                                  )],
             "power_th" => 10000,
             "efficiency_fuel_in" => "const:1.0",
         ),
         "TST_GBO_02" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "power_th" => 40000,
             "efficiency_fuel_in" => "const:1.0",
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_GBO_01",
-                    "TST_BFT_01",
-                    "TST_GBO_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_BFT_01"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 0],
-                    [1, 0]
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_GBO_01",
+                                  "TST_BFT_01",
+                                  "TST_GBO_02"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_BFT_01"],
+                "energy_flow" => [[1, 1],
+                                  [1, 0],
+                                  [1, 0]],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -81,7 +67,7 @@ function test_primary_producer_can_load_storage()
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
             "scale" => 1,
-            "constant_demand" => 20000
+            "constant_demand" => 20000,
         ),
     )
 
@@ -89,7 +75,7 @@ function test_primary_producer_can_load_storage()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -126,14 +112,10 @@ function test_primary_producer_can_load_storage()
     EnergySystems.process(demand, simulation_parameters)
     EnergySystems.process(bus, simulation_parameters)
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[1], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) == 0.0  # balance of busses are always zero
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[3], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[3], bus)
     @test EnergySystems.balance(exchanges) == 0.0  # balance of busses are always zero
 
     EnergySystems.process(boiler_1, simulation_parameters)
@@ -152,14 +134,10 @@ function test_primary_producer_can_load_storage()
     EnergySystems.process(grid_1, simulation_parameters)
     EnergySystems.distribute!(bus)
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[1], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) == 0.0
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[3], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[3], bus)
     @test EnergySystems.balance(exchanges) == 0.0
 
     # in the second timestep, demand is lower than primary producer can provide, so the
@@ -189,9 +167,7 @@ function test_primary_producer_can_load_storage()
     EnergySystems.process(demand, simulation_parameters)
     EnergySystems.process(bus, simulation_parameters)
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[1], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) == 0.0  # balance of busses are always zero
 
     EnergySystems.process(boiler_1, simulation_parameters)
@@ -213,14 +189,10 @@ function test_primary_producer_can_load_storage()
     @test tank.input_interfaces[tank.medium].sum_abs_change == 2000.0
     @test boiler_1.output_interfaces[boiler_2.m_heat_out].sum_abs_change == 5000.0
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[1], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[1], bus)
     @test EnergySystems.balance(exchanges) == 0.0
 
-    exchanges = EnergySystems.balance_on(
-        bus.input_interfaces[3], bus
-    )
+    exchanges = EnergySystems.balance_on(bus.input_interfaces[3], bus)
     @test EnergySystems.balance(exchanges) == 0.0
 end
 

--- a/test/initialization/bus.jl
+++ b/test/initialization/bus.jl
@@ -15,7 +15,7 @@ function energy_system()::Dict{String,Any}
             "type" => "PVPlant",
             "output_refs" => ["TST_BUS_01"],
             "energy_profile_file_path" => "./profiles/tests/source_power_pv.prf",
-            "scale" => 20000
+            "scale" => 20000,
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
@@ -24,18 +24,16 @@ function energy_system()::Dict{String,Any}
         "TST_BAT_01" => Dict{String,Any}(
             "type" => "Battery",
             "output_refs" => ["TST_BUS_01"],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "economical_discharge",
-                    "pv_threshold" => 750.0,
-                    "min_charge" => 0.2,
-                    "discharge_limit" => 0.05,
-                    "pv_plant_uac" => "TST_PVP_01",
-                    "battery_uac" => "TST_BAT_01"
-                )
-            ],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "economical_discharge",
+                                      "pv_threshold" => 750.0,
+                                      "min_charge" => 0.2,
+                                      "discharge_limit" => 0.05,
+                                      "pv_plant_uac" => "TST_PVP_01",
+                                      "battery_uac" => "TST_BAT_01",
+                                  )],
             "capacity" => 10000,
-            "load" => 5000
+            "load" => 5000,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -54,7 +52,7 @@ function test_load_no_connections()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     exception_occured = false
@@ -87,7 +85,7 @@ function test_load_given_lists_empty()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     exception_occured = false
     try
@@ -112,26 +110,20 @@ end
 function test_fully_specified()
     components_config = energy_system()
     components_config["TST_BUS_01"]["connections"] = Dict{String,Any}(
-        "input_order" => [
-            "TST_PVP_01",
-            "TST_BAT_01",
-            "TST_GRI_01",
-        ],
-        "output_order" => [
-            "TST_DEM_01",
-            "TST_BAT_01"
-        ],
-        "energy_flow" => [
-            [1, 1],
-            [1, 0],
-            [1, 0]
-        ]
+        "input_order" => ["TST_PVP_01",
+                          "TST_BAT_01",
+                          "TST_GRI_01"],
+        "output_order" => ["TST_DEM_01",
+                           "TST_BAT_01"],
+        "energy_flow" => [[1, 1],
+                          [1, 0],
+                          [1, 0]],
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/initialization/bus_merge.jl
+++ b/test/initialization/bus_merge.jl
@@ -9,61 +9,49 @@ function energy_system_simple()::Dict{String,Any}
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_01"],
             "constant_supply" => 1500,
-            "constant_temperature" => 65
+            "constant_temperature" => 65,
         ),
         "TST_SRC_02" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_02"],
             "constant_supply" => 500,
-            "constant_temperature" => 40
+            "constant_temperature" => 40,
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_BUS_02"
-                ],
-                "energy_flow" => [
-                    [1,1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_BUS_02"],
+                "energy_flow" => [[1, 1]],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_SRC_02",
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_SRC_02"],
+                "output_order" => ["TST_DEM_02"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 65
+            "constant_temperature" => 65,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 40
+            "constant_temperature" => 40,
         ),
     )
 end
@@ -74,39 +62,29 @@ function test_merge_busses()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
-    busses = Grouping(
-        key => bus for (key,bus) in pairs(components)
-                   if bus.sys_function == EnergySystems.sf_bus
-    )
+    busses = Grouping(key => bus for (key, bus) in pairs(components)
+                      if bus.sys_function == EnergySystems.sf_bus)
     nodes = EnergySystems.nodes_from_components(busses)
-    new_bus = EnergySystems.merge(
-        nodes["TST_BUS_01"],
-        nodes["TST_BUS_02"],
-        "TST_BUS_01" * "TST_BUS_02"
-    )
+    new_bus = EnergySystems.merge(nodes["TST_BUS_01"],
+                                  nodes["TST_BUS_02"],
+                                  "TST_BUS_01" * "TST_BUS_02")
 
-    expected = [
-        "TST_SRC_01",
-        "TST_SRC_02",
-    ]
+    expected = ["TST_SRC_01",
+                "TST_SRC_02"]
     inputs = [f.uac for f in new_bus.inputs]
     @test inputs == expected
 
-    expected = [
-        "TST_DEM_01",
-        "TST_DEM_02",
-    ]
+    expected = ["TST_DEM_01",
+                "TST_DEM_02"]
     outputs = [f.uac for f in new_bus.outputs]
     @test outputs == expected
 
-    expected = [
-        1 1;
-        0 1
-    ]
+    expected = [1 1;
+                0 1]
     @test new_bus.energy_flow == expected
 end
 
@@ -121,35 +99,35 @@ function energy_system_complicated()::Dict{String,Any}
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_01"],
             "constant_supply" => 1500,
-            "constant_temperature" => 65
+            "constant_temperature" => 65,
         ),
         "TST_SRC_02" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_02"],
             "constant_supply" => 500,
-            "constant_temperature" => 60
+            "constant_temperature" => 60,
         ),
         "TST_SRC_03" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_03"],
             "constant_supply" => 500,
-            "constant_temperature" => 55
+            "constant_temperature" => 55,
         ),
         "TST_SRC_04" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_04"],
             "constant_supply" => 500,
-            "constant_temperature" => 50
+            "constant_temperature" => 50,
         ),
         "TST_SRC_05" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_05"],
             "constant_supply" => 500,
-            "constant_temperature" => 45
+            "constant_temperature" => 45,
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "Storage",
@@ -189,139 +167,109 @@ function energy_system_complicated()::Dict{String,Any}
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                    "TST_BFT_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_BFT_01",
-                    "TST_BUS_03"
-                ],
-                "energy_flow" => [
-                    [1,1,1],
-                    [1,0,0],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_01",
+                                  "TST_BFT_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_BFT_01",
+                                   "TST_BUS_03"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 0, 0]],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_02",
-                    "TST_BFT_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                    "TST_BFT_02",
-                    "TST_BUS_03"
-                ],
-                "energy_flow" => [
-                    [1,1,1],
-                    [1,0,0],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_02",
+                                  "TST_BFT_02"],
+                "output_order" => ["TST_DEM_02",
+                                   "TST_BFT_02",
+                                   "TST_BUS_03"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 0, 0]],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_03",
-                    "TST_BUS_02",
-                    "TST_BUS_01",
-                    "TST_BFT_03",
-                ],
-                "output_order" => [
-                    "TST_DEM_03",
-                    "TST_BFT_03",
-                    "TST_BUS_04",
-                    "TST_BUS_05",
-                ],
-                "energy_flow" => [
-                    [1,1,1,1],
-                    [1,1,1,1],
-                    [1,1,1,1],
-                    [1,0,1,1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_03",
+                                  "TST_BUS_02",
+                                  "TST_BUS_01",
+                                  "TST_BFT_03"],
+                "output_order" => ["TST_DEM_03",
+                                   "TST_BFT_03",
+                                   "TST_BUS_04",
+                                   "TST_BUS_05"],
+                "energy_flow" => [[1, 1, 1, 1],
+                                  [1, 1, 1, 1],
+                                  [1, 1, 1, 1],
+                                  [1, 0, 1, 1]],
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_04",
-                    "TST_BUS_03",
-                    "TST_BFT_04"
-                ],
-                "output_order" => [
-                    "TST_DEM_04",
-                    "TST_BFT_04",
-                ],
-                "energy_flow" => [
-                    [1,1],
-                    [1,1],
-                    [1,0],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_04",
+                                  "TST_BUS_03",
+                                  "TST_BFT_04"],
+                "output_order" => ["TST_DEM_04",
+                                   "TST_BFT_04"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1],
+                                  [1, 0]],
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_05",
-                    "TST_BUS_03",
-                    "TST_BFT_05"
-                ],
-                "output_order" => [
-                    "TST_DEM_05",
-                    "TST_BFT_05",
-                ],
-                "energy_flow" => [
-                    [1,1],
-                    [1,1],
-                    [1,0],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_05",
+                                  "TST_BUS_03",
+                                  "TST_BFT_05"],
+                "output_order" => ["TST_DEM_05",
+                                   "TST_BFT_05"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1],
+                                  [1, 0]],
+            ),
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 65
+            "constant_temperature" => 65,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 60
+            "constant_temperature" => 60,
         ),
         "TST_DEM_03" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 55
+            "constant_temperature" => 55,
         ),
         "TST_DEM_04" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 50
+            "constant_temperature" => 50,
         ),
         "TST_DEM_05" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_ht1",
             "output_refs" => [],
             "constant_demand" => 1000,
-            "constant_temperature" => 45
+            "constant_temperature" => 45,
         ),
     )
 end
@@ -332,69 +280,53 @@ function test_merge_busses_cross_shape_half_manual()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
-    busses = Grouping(
-        key => bus for (key,bus) in pairs(components)
-                   if bus.sys_function == EnergySystems.sf_bus
-    )
+    busses = Grouping(key => bus for (key, bus) in pairs(components)
+                      if bus.sys_function == EnergySystems.sf_bus)
     nodes = EnergySystems.nodes_from_components(busses)
-    new_bus = EnergySystems.merge(
-        nodes["TST_BUS_03"],
-        nodes["TST_BUS_05"],
-        "TST_BUS_03" * "TST_BUS_05"
-    )
-    EnergySystems.update_nodes!(
-        nodes, "TST_BUS_03", "TST_BUS_05", new_bus
-    )
-    new_bus = EnergySystems.merge(
-        new_bus,
-        nodes["TST_BUS_04"],
-        new_bus.uac * "TST_BUS_04"
-    )
-    EnergySystems.update_nodes!(
-        nodes,
-        "TST_BUS_04",
-        "TST_BUS_04TST_BUS_03TST_BUS_05",
-        new_bus
-    )
+    new_bus = EnergySystems.merge(nodes["TST_BUS_03"],
+                                  nodes["TST_BUS_05"],
+                                  "TST_BUS_03" * "TST_BUS_05")
+    EnergySystems.update_nodes!(nodes, "TST_BUS_03", "TST_BUS_05", new_bus)
+    new_bus = EnergySystems.merge(new_bus,
+                                  nodes["TST_BUS_04"],
+                                  new_bus.uac * "TST_BUS_04")
+    EnergySystems.update_nodes!(nodes,
+                                "TST_BUS_04",
+                                "TST_BUS_04TST_BUS_03TST_BUS_05",
+                                new_bus)
 
-    expected = [
-        "TST_SRC_04",
-        "TST_SRC_05",
-        "TST_SRC_03",
-        "TST_BUS_02",
-        "TST_BUS_01",
-        "TST_BFT_03",
-        "TST_BFT_05",
-        "TST_BFT_04",
-    ]
+    expected = ["TST_SRC_04",
+                "TST_SRC_05",
+                "TST_SRC_03",
+                "TST_BUS_02",
+                "TST_BUS_01",
+                "TST_BFT_03",
+                "TST_BFT_05",
+                "TST_BFT_04"]
     inputs = [f.uac for f in new_bus.inputs]
     @test inputs == expected
 
-    expected = [
-        "TST_DEM_03",
-        "TST_BFT_03",
-        "TST_DEM_04",
-        "TST_BFT_04",
-        "TST_DEM_05",
-        "TST_BFT_05",
-    ]
+    expected = ["TST_DEM_03",
+                "TST_BFT_03",
+                "TST_DEM_04",
+                "TST_BFT_04",
+                "TST_DEM_05",
+                "TST_BFT_05"]
     outputs = [f.uac for f in new_bus.outputs]
     @test outputs == expected
 
-    expected = [
-        0 0 1 1 0 0;
-        0 0 0 0 1 1;
-        1 1 1 1 1 1;
-        1 1 1 1 1 1;
-        1 1 1 1 1 1;
-        1 0 1 1 1 1;
-        0 0 0 0 1 0;
-        0 0 1 0 0 0;
-    ]
+    expected = [0 0 1 1 0 0;
+                0 0 0 0 1 1;
+                1 1 1 1 1 1;
+                1 1 1 1 1 1;
+                1 1 1 1 1 1;
+                1 0 1 1 1 1;
+                0 0 0 0 1 0;
+                0 0 1 0 0 0]
     @test new_bus.energy_flow == expected
 end
 
@@ -407,142 +339,112 @@ function test_merge_busses_cross_shape_full_manual()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_parameters)
-    busses = Grouping(
-        key => bus for (key,bus) in pairs(components)
-                   if bus.sys_function == EnergySystems.sf_bus
-    )
+    busses = Grouping(key => bus for (key, bus) in pairs(components)
+                      if bus.sys_function == EnergySystems.sf_bus)
     nodes = EnergySystems.nodes_from_components(busses)
-    new_bus = EnergySystems.merge(
-        nodes["TST_BUS_03"],
-        nodes["TST_BUS_05"],
-        "TST_BUS_03" * "TST_BUS_05"
-    )
-    EnergySystems.update_nodes!(
-        nodes,
-        "TST_BUS_03",
-        "TST_BUS_05",
-        new_bus
-    )
-    new_bus = EnergySystems.merge(
-        new_bus,
-        nodes["TST_BUS_04"],
-        new_bus.uac * "TST_BUS_04"
-    )
-    EnergySystems.update_nodes!(
-        nodes,
-        "TST_BUS_03TST_BUS_05",
-        "TST_BUS_04",
-        new_bus
-    )
-    new_bus = EnergySystems.merge(
-        nodes["TST_BUS_01"],
-        new_bus,
-        new_bus.uac * "TST_BUS_01"
-    )
-    EnergySystems.update_nodes!(
-        nodes,
-        "TST_BUS_01",
-        "TST_BUS_03TST_BUS_05TST_BUS_04",
-        new_bus
-    )
+    new_bus = EnergySystems.merge(nodes["TST_BUS_03"],
+                                  nodes["TST_BUS_05"],
+                                  "TST_BUS_03" * "TST_BUS_05")
+    EnergySystems.update_nodes!(nodes,
+                                "TST_BUS_03",
+                                "TST_BUS_05",
+                                new_bus)
+    new_bus = EnergySystems.merge(new_bus,
+                                  nodes["TST_BUS_04"],
+                                  new_bus.uac * "TST_BUS_04")
+    EnergySystems.update_nodes!(nodes,
+                                "TST_BUS_03TST_BUS_05",
+                                "TST_BUS_04",
+                                new_bus)
+    new_bus = EnergySystems.merge(nodes["TST_BUS_01"],
+                                  new_bus,
+                                  new_bus.uac * "TST_BUS_01")
+    EnergySystems.update_nodes!(nodes,
+                                "TST_BUS_01",
+                                "TST_BUS_03TST_BUS_05TST_BUS_04",
+                                new_bus)
 
-    expected = [
-        "TST_SRC_04",
-        "TST_SRC_05",
-        "TST_SRC_03",
-        "TST_BUS_02",
-        "TST_SRC_01",
-        "TST_BFT_01",
-        "TST_BFT_03",
-        "TST_BFT_05",
-        "TST_BFT_04",
-    ]
+    expected = ["TST_SRC_04",
+                "TST_SRC_05",
+                "TST_SRC_03",
+                "TST_BUS_02",
+                "TST_SRC_01",
+                "TST_BFT_01",
+                "TST_BFT_03",
+                "TST_BFT_05",
+                "TST_BFT_04"]
     inputs = [f.uac for f in new_bus.inputs]
     @test inputs == expected
 
-    expected = [
-        "TST_DEM_01",
-        "TST_BFT_01",
-        "TST_DEM_03",
-        "TST_BFT_03",
-        "TST_DEM_04",
-        "TST_BFT_04",
-        "TST_DEM_05",
-        "TST_BFT_05",
-    ]
+    expected = ["TST_DEM_01",
+                "TST_BFT_01",
+                "TST_DEM_03",
+                "TST_BFT_03",
+                "TST_DEM_04",
+                "TST_BFT_04",
+                "TST_DEM_05",
+                "TST_BFT_05"]
     outputs = [f.uac for f in new_bus.outputs]
     @test outputs == expected
 
-    expected = [
-        0 0 0 0 1 1 0 0;
-        0 0 0 0 0 0 1 1;
-        0 0 1 1 1 1 1 1;
-        0 0 1 1 1 1 1 1;
-        1 1 1 1 1 1 1 1;
-        1 0 0 0 0 0 0 0;
-        0 0 1 0 1 1 1 1;
-        0 0 0 0 0 0 1 0;
-        0 0 0 0 1 0 0 0;
-    ]
+    expected = [0 0 0 0 1 1 0 0;
+                0 0 0 0 0 0 1 1;
+                0 0 1 1 1 1 1 1;
+                0 0 1 1 1 1 1 1;
+                1 1 1 1 1 1 1 1;
+                1 0 0 0 0 0 0 0;
+                0 0 1 0 1 1 1 1;
+                0 0 0 0 0 0 1 0;
+                0 0 0 0 1 0 0 0]
     @test new_bus.energy_flow == expected
 
-    new_bus = EnergySystems.merge(
-        nodes["TST_BUS_02"],
-        new_bus,
-        "TST_BUS_02" * new_bus.uac
-    )
-    EnergySystems.update_nodes!(
-        nodes,
-        "TST_BUS_02",
-        "TST_BUS_01TST_BUS_03TST_BUS_05TST_BUS_04",
-        new_bus
-    )
+    new_bus = EnergySystems.merge(nodes["TST_BUS_02"],
+                                  new_bus,
+                                  "TST_BUS_02" * new_bus.uac)
+    EnergySystems.update_nodes!(nodes,
+                                "TST_BUS_02",
+                                "TST_BUS_01TST_BUS_03TST_BUS_05TST_BUS_04",
+                                new_bus)
 
-    expected = [
-        "TST_SRC_04",
-        "TST_SRC_05",
-        "TST_SRC_03",
-        "TST_SRC_02",
-        "TST_BFT_02",
-        "TST_SRC_01",
-        "TST_BFT_01",
-        "TST_BFT_03",
-        "TST_BFT_05",
-        "TST_BFT_04",
-    ]
+    expected = ["TST_SRC_04",
+                "TST_SRC_05",
+                "TST_SRC_03",
+                "TST_SRC_02",
+                "TST_BFT_02",
+                "TST_SRC_01",
+                "TST_BFT_01",
+                "TST_BFT_03",
+                "TST_BFT_05",
+                "TST_BFT_04"]
     inputs = [f.uac for f in new_bus.inputs]
     @test inputs == expected
 
-    expected = [
-        "TST_DEM_02",
-        "TST_BFT_02",
-        "TST_DEM_01",
-        "TST_BFT_01",
-        "TST_DEM_03",
-        "TST_BFT_03",
-        "TST_DEM_04",
-        "TST_BFT_04",
-        "TST_DEM_05",
-        "TST_BFT_05",
-    ]
+    expected = ["TST_DEM_02",
+                "TST_BFT_02",
+                "TST_DEM_01",
+                "TST_BFT_01",
+                "TST_DEM_03",
+                "TST_BFT_03",
+                "TST_DEM_04",
+                "TST_BFT_04",
+                "TST_DEM_05",
+                "TST_BFT_05"]
     outputs = [f.uac for f in new_bus.outputs]
     @test outputs == expected
 
-    expected = [
-        0 0 0 0 0 0 1 1 0 0;
-        0 0 0 0 0 0 0 0 1 1;
-        0 0 0 0 1 1 1 1 1 1;
-        1 1 0 0 1 1 1 1 1 1;
-        1 0 0 0 0 0 0 0 0 0;
-        0 0 1 1 1 1 1 1 1 1;
-        0 0 1 0 0 0 0 0 0 0;
-        0 0 0 0 1 0 1 1 1 1;
-        0 0 0 0 0 0 0 0 1 0;
-        0 0 0 0 0 0 1 0 0 0;
-    ]
+    expected = [0 0 0 0 0 0 1 1 0 0;
+                0 0 0 0 0 0 0 0 1 1;
+                0 0 0 0 1 1 1 1 1 1;
+                1 1 0 0 1 1 1 1 1 1;
+                1 0 0 0 0 0 0 0 0 0;
+                0 0 1 1 1 1 1 1 1 1;
+                0 0 1 0 0 0 0 0 0 0;
+                0 0 0 0 1 0 1 1 1 1;
+                0 0 0 0 0 0 0 0 1 0;
+                0 0 0 0 0 0 1 0 0 0]
     @test new_bus.energy_flow == expected
 end
 
@@ -555,95 +457,79 @@ function test_merge_busses_cross_shape_full_automatic()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_parameters)
-    busses = Grouping(
-        key => bus for (key,bus) in pairs(components)
-                   if bus.sys_function == EnergySystems.sf_bus
-    )
+    busses = Grouping(key => bus for (key, bus) in pairs(components)
+                      if bus.sys_function == EnergySystems.sf_bus)
     new_bus = EnergySystems.merge_busses(busses, components)
 
-    expected = [
-        "TST_SRC_04",
-        "TST_SRC_05",
-        "TST_SRC_03",
-        "TST_SRC_02",
-        "TST_BFT_02",
-        "TST_SRC_01",
-        "TST_BFT_01",
-        "TST_BFT_03",
-        "TST_BFT_05",
-        "TST_BFT_04",
-    ]
+    expected = ["TST_SRC_04",
+                "TST_SRC_05",
+                "TST_SRC_03",
+                "TST_SRC_02",
+                "TST_BFT_02",
+                "TST_SRC_01",
+                "TST_BFT_01",
+                "TST_BFT_03",
+                "TST_BFT_05",
+                "TST_BFT_04"]
     inputs = [f.source.uac for f in new_bus.input_interfaces]
     @test inputs == expected
     @test new_bus.connectivity.input_order == expected
 
-    expected = [
-        "TST_DEM_02",
-        "TST_BFT_02",
-        "TST_DEM_01",
-        "TST_BFT_01",
-        "TST_DEM_03",
-        "TST_BFT_03",
-        "TST_DEM_04",
-        "TST_BFT_04",
-        "TST_DEM_05",
-        "TST_BFT_05",
-    ]
+    expected = ["TST_DEM_02",
+                "TST_BFT_02",
+                "TST_DEM_01",
+                "TST_BFT_01",
+                "TST_DEM_03",
+                "TST_BFT_03",
+                "TST_DEM_04",
+                "TST_BFT_04",
+                "TST_DEM_05",
+                "TST_BFT_05"]
     outputs = [f.target.uac for f in new_bus.output_interfaces]
     @test outputs == expected
     @test new_bus.connectivity.output_order == expected
 
-    expected = [
-        ("TST_SRC_04",1),
-        ("TST_SRC_05",2),
-        ("TST_SRC_03",3),
-        ("TST_SRC_02",4),
-        ("TST_BFT_02",5),
-        ("TST_SRC_01",6),
-        ("TST_BFT_01",7),
-        ("TST_BFT_03",8),
-        ("TST_BFT_05",9),
-        ("TST_BFT_04",10),
-    ]
-    inputs = [
-        (row.source.uac, row.priority)
-        for row in sort(collect(values(new_bus.balance_table_inputs)), by=x->x.priority)
-    ]
+    expected = [("TST_SRC_04", 1),
+                ("TST_SRC_05", 2),
+                ("TST_SRC_03", 3),
+                ("TST_SRC_02", 4),
+                ("TST_BFT_02", 5),
+                ("TST_SRC_01", 6),
+                ("TST_BFT_01", 7),
+                ("TST_BFT_03", 8),
+                ("TST_BFT_05", 9),
+                ("TST_BFT_04", 10)]
+    inputs = [(row.source.uac, row.priority)
+              for row in sort(collect(values(new_bus.balance_table_inputs)); by=x -> x.priority)]
     @test inputs == expected
 
-    expected = [
-        ("TST_DEM_02",1),
-        ("TST_BFT_02",2),
-        ("TST_DEM_01",3),
-        ("TST_BFT_01",4),
-        ("TST_DEM_03",5),
-        ("TST_BFT_03",6),
-        ("TST_DEM_04",7),
-        ("TST_BFT_04",8),
-        ("TST_DEM_05",9),
-        ("TST_BFT_05",10),
-    ]
-    outputs = [
-        (row.target.uac, row.priority)
-        for row in sort(collect(values(new_bus.balance_table_outputs)), by=x->x.priority)
-    ]
+    expected = [("TST_DEM_02", 1),
+                ("TST_BFT_02", 2),
+                ("TST_DEM_01", 3),
+                ("TST_BFT_01", 4),
+                ("TST_DEM_03", 5),
+                ("TST_BFT_03", 6),
+                ("TST_DEM_04", 7),
+                ("TST_BFT_04", 8),
+                ("TST_DEM_05", 9),
+                ("TST_BFT_05", 10)]
+    outputs = [(row.target.uac, row.priority)
+               for row in sort(collect(values(new_bus.balance_table_outputs)); by=x -> x.priority)]
     @test outputs == expected
 
-    expected = [
-        [0,0,0,0,0,0,1,1,0,0],
-        [0,0,0,0,0,0,0,0,1,1],
-        [0,0,0,0,1,1,1,1,1,1],
-        [1,1,0,0,1,1,1,1,1,1],
-        [1,0,0,0,0,0,0,0,0,0],
-        [0,0,1,1,1,1,1,1,1,1],
-        [0,0,1,0,0,0,0,0,0,0],
-        [0,0,0,0,1,0,1,1,1,1],
-        [0,0,0,0,0,0,0,0,1,0],
-        [0,0,0,0,0,0,1,0,0,0],
-    ]
+    expected = [[0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+                [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                [1, 1, 0, 0, 1, 1, 1, 1, 1, 1],
+                [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+                [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0, 1, 1, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0]]
     @test new_bus.connectivity.energy_flow == expected
 end
 
@@ -656,105 +542,73 @@ function energy_system_busses_only()::Dict{String,Any}
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => [
-                    "TST_BUS_03"
-                ],
-            )
+                "output_order" => ["TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => [
-                    "TST_BUS_04"
-                ],
-            )
+                "output_order" => ["TST_BUS_04"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_04",
-                ],
-                "energy_flow" => [
-                    [1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_BUS_04"],
+                "energy_flow" => [[1]],
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_02",
-                    "TST_BUS_03",
-                ],
-                "output_order" => [
-                    "TST_BUS_05",
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_02",
+                                  "TST_BUS_03"],
+                "output_order" => ["TST_BUS_05"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_04",
-                ],
-                "output_order" => [
-                    "TST_BUS_06",
-                    "TST_BUS_07",
-                ],
-                "energy_flow" => [
-                    [1,1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_04"],
+                "output_order" => ["TST_BUS_06",
+                                   "TST_BUS_07"],
+                "energy_flow" => [[1, 1]],
+            ),
         ),
         "TST_BUS_06" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_05",
-                ],
-                "output_order" => [
-                    "TST_BUS_08",
-                ],
-                "energy_flow" => [
-                    [1],
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_05"],
+                "output_order" => ["TST_BUS_08"],
+                "energy_flow" => [[1]],
+            ),
         ),
         "TST_BUS_07" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_05",
-                ],
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_05"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_08" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_06",
-                ],
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_06"],
                 "output_order" => [],
-            )
+            ),
         ),
     )
 end
@@ -764,7 +618,7 @@ function test_merge_busses_order_of_merges()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_parameters)
     chains = Resie.find_chains(values(components), EnergySystems.sf_bus)
@@ -784,11 +638,9 @@ function test_merge_preserves_storage_transfer()
     components_config = energy_system_simple()
     push!(components_config["TST_BUS_02"]["connections"]["input_order"], "TST_BFT_02")
     push!(components_config["TST_BUS_02"]["connections"]["output_order"], "TST_BFT_02")
-    components_config["TST_BUS_02"]["connections"]["energy_flow"] = [
-        [1,1],
-        [1,1],
-        [1,0],
-    ]
+    components_config["TST_BUS_02"]["connections"]["energy_flow"] = [[1, 1],
+                                                                     [1, 1],
+                                                                     [1, 0]]
     components_config["TST_BFT_02"] = Dict{String,Any}(
         "type" => "Storage",
         "medium" => "m_h_w_ht1",
@@ -797,43 +649,35 @@ function test_merge_preserves_storage_transfer()
         "load" => 2000,
     )
     components_config["TST_SRC_01"]["control_parameters"] = Dict{String,Any}(
-        "load_storages m_h_w_ht1" => false
+        "load_storages m_h_w_ht1" => false,
     )
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_parameters)
-    busses = Grouping(
-        key => bus for (key,bus) in pairs(components)
-                   if bus.sys_function == EnergySystems.sf_bus
-    )
+    busses = Grouping(key => bus for (key, bus) in pairs(components)
+                      if bus.sys_function == EnergySystems.sf_bus)
     new_bus = EnergySystems.merge_busses(busses, components)
 
-    expected = [
-        "TST_SRC_01",
-        "TST_SRC_02",
-        "TST_BFT_02",
-    ]
+    expected = ["TST_SRC_01",
+                "TST_SRC_02",
+                "TST_BFT_02"]
     inputs = [f.source.uac for f in new_bus.input_interfaces]
     @test inputs == expected
     @test new_bus.connectivity.input_order == expected
 
-    expected = [
-        "TST_DEM_01",
-        "TST_DEM_02",
-        "TST_BFT_02",
-    ]
+    expected = ["TST_DEM_01",
+                "TST_DEM_02",
+                "TST_BFT_02"]
     outputs = [f.target.uac for f in new_bus.output_interfaces]
     @test outputs == expected
     @test new_bus.connectivity.output_order == expected
 
-    expected = [
-        [1,1,1],
-        [0,1,1],
-        [0,1,0],
-    ]
+    expected = [[1, 1, 1],
+                [0, 1, 1],
+                [0, 1, 0]]
     @test new_bus.connectivity.energy_flow == expected
 
     @test new_bus.input_interfaces[1].source.uac == "TST_SRC_01"

--- a/test/initialization/loading.jl
+++ b/test/initialization/loading.jl
@@ -20,16 +20,14 @@ function test_load_from_dict()
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "output_refs" => ["TST_BT_01"],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "storage_driven",
-                    "high_threshold" => 0.5,
-                    "low_threshold" => 0.1,
-                    "storage_uac" => "TST_BT_01"
-                )
-            ],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "storage_driven",
+                                      "high_threshold" => 0.5,
+                                      "low_threshold" => 0.1,
+                                      "storage_uac" => "TST_BT_01",
+                                  )],
             "power_th" => 20000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
         "TST_BT_01" => Dict{String,Any}(
             "type" => "BufferTank",
@@ -49,7 +47,7 @@ function test_load_from_dict()
     simulation_params = Dict{String,Any}(
         "time" => 0,
         "time_step_seconds" => 900,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_params)
     @test length(keys(components)) == 5
@@ -78,11 +76,9 @@ function test_load_custom_medium_categories()
         ),
         "TST_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_HP_01",
-                "TST_GRO_02",
-                "TST_GRO_03"
-            ],
+            "output_refs" => ["TST_HP_01",
+                              "TST_GRO_02",
+                              "TST_GRO_03"],
             "power_el" => 1000,
             "m_el_in" => "m_e_dc_1000v",
             "m_heat_ht_out" => "m_h_w_55c",
@@ -97,7 +93,7 @@ function test_load_custom_medium_categories()
             "m_heat_in" => "m_h_w_55c",
             "m_heat_out" => "m_h_w_85c",
             "power_th" => 12000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
         "TST_GRO_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -121,7 +117,7 @@ function test_load_custom_medium_categories()
     simulation_params = Dict{String,Any}(
         "time" => 0,
         "time_step_seconds" => 900,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
     components = Resie.load_components(components_config, simulation_params)
     electrolyser = components["TST_ELY_01"]

--- a/test/initialization/profiles.jl
+++ b/test/initialization/profiles.jl
@@ -18,11 +18,10 @@ function energy_system()::Dict{String,Any}
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/heating_demand_short.prf",
             "temperature_profile_file_path" => "./profiles/tests/temperature_short.prf",
-            "scale" => 1
+            "scale" => 1,
         ),
     )
 end
-
 
 function test_profile_aggregation_two()
     components_config = energy_system()
@@ -30,7 +29,7 @@ function test_profile_aggregation_two()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 1800,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -52,7 +51,7 @@ function test_profile_aggregation_four()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 3600,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -74,7 +73,7 @@ function test_profile_segmentation_half()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 450,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -82,12 +81,14 @@ function test_profile_segmentation_half()
 
     @test demand.energy_profile.time_step == 450
     @test demand.energy_profile.is_power == false
-    @test demand.energy_profile.data == [5,5,6,6,30,30,0,0,1.25,1.25,11.5,11.5,2.5,2.5,5.5,5.5,0.5,0.5,21,21]
+    @test demand.energy_profile.data ==
+          [5, 5, 6, 6, 30, 30, 0, 0, 1.25, 1.25, 11.5, 11.5, 2.5, 2.5, 5.5, 5.5, 0.5, 0.5, 21, 21]
     @test sum(demand.energy_profile.data) == 166.5
 
     @test demand.temperature_profile.time_step == 450
     @test demand.temperature_profile.is_power == true
-    @test demand.temperature_profile.data == [65,64,63,66.5,70,69,68,70,72,72,72,64,56,58.5,61,63.5,66,68,70,70]
+    @test demand.temperature_profile.data ==
+          [65, 64, 63, 66.5, 70, 69, 68, 70, 72, 72, 72, 64, 56, 58.5, 61, 63.5, 66, 68, 70, 70]
 end
 
 function test_profile_segmentation_third()
@@ -96,7 +97,7 @@ function test_profile_segmentation_third()
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 300,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -104,41 +105,43 @@ function test_profile_segmentation_third()
 
     @test demand.energy_profile.time_step == 300
     @test demand.energy_profile.is_power == false
-    @test all(demand.energy_profile.data .- [10,10,10,12,12,12,60,60,60,0,0,0,2.5,2.5,2.5,23,23,23,5,5,5,11,11,11,1,1,1,42,42,42]./3 .< simulation_parameters["epsilon"]) == true
+    @test all(demand.energy_profile.data .-
+              [10, 10, 10, 12, 12, 12, 60, 60, 60, 0, 0, 0, 2.5, 2.5, 2.5, 23, 23, 23, 5, 5, 5, 11, 11, 11, 1, 1, 1, 42,
+               42, 42] ./ 3 .< simulation_parameters["epsilon"]) == true
     @test sum(demand.energy_profile.data) == 166.5
 
     @test demand.temperature_profile.time_step == 300
     @test demand.temperature_profile.is_power == true
-    @test all(demand.temperature_profile.data .- [  65,
-                                                64.33333333333334,
-                                                63.66666666666667,
-                                                63,
-                                                65.33333333333334,
-                                                67.66666666666667,
-                                                70,
-                                                69.33333333333334,
-                                                68.66666666666667,
-                                                68,
-                                                69.33333333333334,
-                                                70.66666666666667,
-                                                72,
-                                                72,
-                                                72,
-                                                72,
-                                                66.66666666666667,
-                                                61.33333333333334,
-                                                56,
-                                                57.66666666666667,
-                                                59.33333333333334,
-                                                61,
-                                                62.66666666666667,
-                                                64.33333333333334,
-                                                66,
-                                                67.33333333333334,
-                                                68.66666666666667,
-                                                70,
-                                                70,
-                                                70] .< simulation_parameters["epsilon"]) == true
+    @test all(demand.temperature_profile.data .- [65,
+                                                  64.33333333333334,
+                                                  63.66666666666667,
+                                                  63,
+                                                  65.33333333333334,
+                                                  67.66666666666667,
+                                                  70,
+                                                  69.33333333333334,
+                                                  68.66666666666667,
+                                                  68,
+                                                  69.33333333333334,
+                                                  70.66666666666667,
+                                                  72,
+                                                  72,
+                                                  72,
+                                                  72,
+                                                  66.66666666666667,
+                                                  61.33333333333334,
+                                                  56,
+                                                  57.66666666666667,
+                                                  59.33333333333334,
+                                                  61,
+                                                  62.66666666666667,
+                                                  64.33333333333334,
+                                                  66,
+                                                  67.33333333333334,
+                                                  68.66666666666667,
+                                                  70,
+                                                  70,
+                                                  70] .< simulation_parameters["epsilon"]) == true
 end
 
 @testset "profiles" begin

--- a/test/order_of_operations/bus_output_priorities.jl
+++ b/test/order_of_operations/bus_output_priorities.jl
@@ -23,39 +23,27 @@ function test_ooo_bus_output_priorities()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_GBO_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BUS_03"
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_GBO_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_DEM_01"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_DEM_02"],
+            ),
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -63,7 +51,7 @@ function test_ooo_bus_output_priorities()
             "output_refs" => [],
             "constant_demand" => 1000,
             "constant_temperature" => 60,
-            "scale" => 1
+            "scale" => 1,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -71,52 +59,49 @@ function test_ooo_bus_output_priorities()
             "output_refs" => [],
             "constant_demand" => 1000,
             "constant_temperature" => 60,
-            "scale" => 1
+            "scale" => 1,
         ),
     )
 
-    expected = [
-        ("TST_DEM_02", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BUS_01", EnergySystems.s_reset),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BUS_03", EnergySystems.s_reset),
-        ("TST_GBO_01", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_02", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_03", EnergySystems.s_control),
-        ("TST_GBO_01", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_02", EnergySystems.s_process),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_BUS_02", EnergySystems.s_process),
-        ("TST_BUS_01", EnergySystems.s_process),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_process),
-        ("TST_BUS_03", EnergySystems.s_process),
-        ("TST_GBO_01", EnergySystems.s_process),
-        ("TST_GRI_01", EnergySystems.s_process),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_01", EnergySystems.s_distribute),
-        ("TST_BUS_03", EnergySystems.s_distribute),
-    ]
+    expected = [("TST_DEM_02", EnergySystems.s_reset),
+                ("TST_DEM_01", EnergySystems.s_reset),
+                ("TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BUS_01", EnergySystems.s_reset),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BUS_03", EnergySystems.s_reset),
+                ("TST_GBO_01", EnergySystems.s_reset),
+                ("TST_GRI_01", EnergySystems.s_reset),
+                ("TST_DEM_02", EnergySystems.s_control),
+                ("TST_DEM_01", EnergySystems.s_control),
+                ("TST_BUS_02", EnergySystems.s_control),
+                ("TST_BUS_01", EnergySystems.s_control),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_control),
+                ("TST_BUS_03", EnergySystems.s_control),
+                ("TST_GBO_01", EnergySystems.s_control),
+                ("TST_GRI_01", EnergySystems.s_control),
+                ("TST_DEM_02", EnergySystems.s_process),
+                ("TST_DEM_01", EnergySystems.s_process),
+                ("TST_BUS_02", EnergySystems.s_process),
+                ("TST_BUS_01", EnergySystems.s_process),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_process),
+                ("TST_BUS_03", EnergySystems.s_process),
+                ("TST_GBO_01", EnergySystems.s_process),
+                ("TST_GRI_01", EnergySystems.s_process),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_01", EnergySystems.s_distribute),
+                ("TST_BUS_03", EnergySystems.s_distribute)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
     ooo = Resie.calculate_order_of_operations(components)
     @test pwc_steps_astr(expected, ooo) == ""
 end
-
 
 @testset "ooo_bus_output_priorities" begin
     test_ooo_bus_output_priorities()

--- a/test/order_of_operations/bus_to_bus.jl
+++ b/test/order_of_operations/bus_to_bus.jl
@@ -17,46 +17,34 @@ function test_ooo_bus_to_bus()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BFT_01"
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BFT_01"],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
-            "load" => 20000
+            "load" => 20000,
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_02",
-                    "TST_BUS_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_BFT_02"
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_02",
+                                  "TST_BUS_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_BFT_02"],
+            ),
         ),
         "TST_BFT_02" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_02"
-            ],
+            "output_refs" => ["TST_BUS_02"],
             "capacity" => 20000,
-            "load" => 10000
+            "load" => 10000,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -64,43 +52,41 @@ function test_ooo_bus_to_bus()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1000
+            "scale" => 1000,
         ),
     )
 
-    expected = [
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BUS_01", EnergySystems.s_reset),
-        ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BFT_02", EnergySystems.s_reset),
-        ("TST_BFT_01", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_control),
-        ("TST_BFT_02", EnergySystems.s_control),
-        ("TST_BFT_01", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_BUS_02", EnergySystems.s_process),
-        ("TST_BUS_01", EnergySystems.s_process),
-        ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_process),
-        ("TST_BFT_02", EnergySystems.s_process),
-        ("TST_BFT_01", EnergySystems.s_process),
-        ("TST_BFT_02", EnergySystems.s_load),
-        ("TST_BFT_01", EnergySystems.s_load),
-        ("TST_GRI_01", EnergySystems.s_process),
-        ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_01", EnergySystems.s_distribute),
-    ]
+    expected = [("TST_DEM_01", EnergySystems.s_reset),
+                ("TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BUS_01", EnergySystems.s_reset),
+                ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BFT_02", EnergySystems.s_reset),
+                ("TST_BFT_01", EnergySystems.s_reset),
+                ("TST_GRI_01", EnergySystems.s_reset),
+                ("TST_DEM_01", EnergySystems.s_control),
+                ("TST_BUS_02", EnergySystems.s_control),
+                ("TST_BUS_01", EnergySystems.s_control),
+                ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_control),
+                ("TST_BFT_02", EnergySystems.s_control),
+                ("TST_BFT_01", EnergySystems.s_control),
+                ("TST_GRI_01", EnergySystems.s_control),
+                ("TST_DEM_01", EnergySystems.s_process),
+                ("TST_BUS_02", EnergySystems.s_process),
+                ("TST_BUS_01", EnergySystems.s_process),
+                ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_process),
+                ("TST_BFT_02", EnergySystems.s_process),
+                ("TST_BFT_01", EnergySystems.s_process),
+                ("TST_BFT_02", EnergySystems.s_load),
+                ("TST_BFT_01", EnergySystems.s_load),
+                ("TST_GRI_01", EnergySystems.s_process),
+                ("Proxy-TST_BUS_01|TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_01", EnergySystems.s_distribute)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/order_of_operations/heat_pumps_wrong.jl
+++ b/test/order_of_operations/heat_pumps_wrong.jl
@@ -13,7 +13,7 @@ function test_ooo_for_heat_pumps_wrong()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
@@ -21,7 +21,7 @@ function test_ooo_for_heat_pumps_wrong()
             "output_refs" => ["TST_HP_01"],
             "max_power_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 6000
+            "scale" => 6000,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -33,29 +33,27 @@ function test_ooo_for_heat_pumps_wrong()
             "type" => "HeatPump",
             "output_refs" => ["TST_DEM_01"],
             "power_th" => 12000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
     )
 
-    expected = [
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_HP_01", EnergySystems.s_reset),
-        ("TST_SRC_01", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_HP_01", EnergySystems.s_control),
-        ("TST_SRC_01", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_HP_01", EnergySystems.s_process),
-        ("TST_SRC_01", EnergySystems.s_process),
-        ("TST_GRI_01", EnergySystems.s_process),
-    ]
+    expected = [("TST_DEM_01", EnergySystems.s_reset),
+                ("TST_HP_01", EnergySystems.s_reset),
+                ("TST_SRC_01", EnergySystems.s_reset),
+                ("TST_GRI_01", EnergySystems.s_reset),
+                ("TST_DEM_01", EnergySystems.s_control),
+                ("TST_HP_01", EnergySystems.s_control),
+                ("TST_SRC_01", EnergySystems.s_control),
+                ("TST_GRI_01", EnergySystems.s_control),
+                ("TST_DEM_01", EnergySystems.s_process),
+                ("TST_HP_01", EnergySystems.s_process),
+                ("TST_SRC_01", EnergySystems.s_process),
+                ("TST_GRI_01", EnergySystems.s_process)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/order_of_operations/load_order_of_operation.jl
+++ b/test/order_of_operations/load_order_of_operation.jl
@@ -8,90 +8,78 @@ include("../test_util.jl")
 function load_order_of_operation()
     components_config = Dict{String,Any}(
         "TST_DEM_01" => Dict{String,Any}(
-            "type"=> "Demand",
-            "medium"=> "m_h_w_ht1",
-            "output_refs"=> [],
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1500
+            "scale" => 1500,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "max_power_profile_file_path" => "./profiles/tests/source_heat_max_power.prf",
             "temperature_profile_file_path" => "./profiles/tests/source_heat_temperature.prf",
-            "scale" => 6000
+            "scale" => 6000,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_HP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_DEM_01"
-            ],
+            "output_refs" => ["TST_DEM_01"],
             "power_th" => 9000,
             "constant_cop" => 3.0,
-            "min_power_fraction" => 0.0
-        )  
+            "min_power_fraction" => 0.0,
+        ),
     )
-    order_of_operation = [
-        "TST_DEM_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_HP_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_DEM_01 s_process",
-        "TST_HP_01 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_HP_01 s_reset",
-    ]
+    order_of_operation = ["TST_DEM_01 s_reset",
+                          "TST_SRC_01 s_reset",
+                          "TST_GRI_01 s_reset",
+                          "TST_DEM_01 s_control",
+                          "TST_HP_01 s_control",
+                          "TST_SRC_01 s_control",
+                          "TST_GRI_01 s_control",
+                          "TST_DEM_01 s_process",
+                          "TST_HP_01 s_process",
+                          "TST_SRC_01 s_process",
+                          "TST_GRI_01 s_process",
+                          "TST_HP_01 s_reset"]
 
-    expected_order_from_input_file = [
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_SRC_01", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_HP_01", EnergySystems.s_control),
-        ("TST_SRC_01", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_HP_01", EnergySystems.s_process),
-        ("TST_SRC_01", EnergySystems.s_process),
-        ("TST_GRI_01", EnergySystems.s_process),
-        ("TST_HP_01", EnergySystems.s_reset)
-    ]
+    expected_order_from_input_file = [("TST_DEM_01", EnergySystems.s_reset),
+                                      ("TST_SRC_01", EnergySystems.s_reset),
+                                      ("TST_GRI_01", EnergySystems.s_reset),
+                                      ("TST_DEM_01", EnergySystems.s_control),
+                                      ("TST_HP_01", EnergySystems.s_control),
+                                      ("TST_SRC_01", EnergySystems.s_control),
+                                      ("TST_GRI_01", EnergySystems.s_control),
+                                      ("TST_DEM_01", EnergySystems.s_process),
+                                      ("TST_HP_01", EnergySystems.s_process),
+                                      ("TST_SRC_01", EnergySystems.s_process),
+                                      ("TST_GRI_01", EnergySystems.s_process),
+                                      ("TST_HP_01", EnergySystems.s_reset)]
 
-    expected_order_calculated = [
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_HP_01", EnergySystems.s_reset),
-        ("TST_SRC_01", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_HP_01", EnergySystems.s_control),
-        ("TST_SRC_01", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_HP_01", EnergySystems.s_process),
-        ("TST_SRC_01", EnergySystems.s_process),
-        ("TST_GRI_01", EnergySystems.s_process)
-    ]
+    expected_order_calculated = [("TST_DEM_01", EnergySystems.s_reset),
+                                 ("TST_HP_01", EnergySystems.s_reset),
+                                 ("TST_SRC_01", EnergySystems.s_reset),
+                                 ("TST_GRI_01", EnergySystems.s_reset),
+                                 ("TST_DEM_01", EnergySystems.s_control),
+                                 ("TST_HP_01", EnergySystems.s_control),
+                                 ("TST_SRC_01", EnergySystems.s_control),
+                                 ("TST_GRI_01", EnergySystems.s_control),
+                                 ("TST_DEM_01", EnergySystems.s_process),
+                                 ("TST_HP_01", EnergySystems.s_process),
+                                 ("TST_SRC_01", EnergySystems.s_process),
+                                 ("TST_GRI_01", EnergySystems.s_process)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -103,9 +91,7 @@ function load_order_of_operation()
     # from ooo calculation
     order_calculated = Resie.calculate_order_of_operations(components)
     @test pwc_steps_astr(expected_order_calculated, order_calculated) == ""
-
 end
-
 
 @testset "load_order_of_operation" begin
     load_order_of_operation()

--- a/test/order_of_operations/one_bus_to_many_with_storage.jl
+++ b/test/order_of_operations/one_bus_to_many_with_storage.jl
@@ -18,43 +18,31 @@ function test_ooo_one_bus_to_many_with_storage()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_SRC_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BUS_03",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_TES_01",
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_TES_01",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_TES_01"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_TES_01"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_TES_02",
-                ],
-                "output_order" => [
-                    "TST_DEM_02",
-                    "TST_TES_02",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_TES_02"],
+                "output_order" => ["TST_DEM_02",
+                                   "TST_TES_02"],
+            ),
         ),
         "TST_TES_01" => Dict{String,Any}(
             "type" => "Storage",
@@ -86,46 +74,44 @@ function test_ooo_one_bus_to_many_with_storage()
         ),
     )
 
-    expected = [
-        ("TST_DEM_02", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BUS_01", EnergySystems.s_reset),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_reset),
-        ("TST_BUS_03", EnergySystems.s_reset),
-        ("TST_TES_02", EnergySystems.s_reset),
-        ("TST_TES_01", EnergySystems.s_reset),
-        ("TST_SRC_01", EnergySystems.s_reset),
-        ("TST_DEM_02", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_03", EnergySystems.s_control),
-        ("TST_TES_02", EnergySystems.s_control),
-        ("TST_TES_01", EnergySystems.s_control),
-        ("TST_SRC_01", EnergySystems.s_control),
-        ("TST_DEM_02", EnergySystems.s_process),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_BUS_02", EnergySystems.s_process),
-        ("TST_BUS_01", EnergySystems.s_process),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_process),
-        ("TST_BUS_03", EnergySystems.s_process),
-        ("TST_SRC_01", EnergySystems.s_process),
-        ("TST_TES_02", EnergySystems.s_process),
-        ("TST_TES_01", EnergySystems.s_process),
-        ("TST_TES_01", EnergySystems.s_load),
-        ("TST_TES_02", EnergySystems.s_load),
-        ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_02", EnergySystems.s_distribute),
-        ("TST_BUS_01", EnergySystems.s_distribute),
-        ("TST_BUS_03", EnergySystems.s_distribute),
-    ]
+    expected = [("TST_DEM_02", EnergySystems.s_reset),
+                ("TST_DEM_01", EnergySystems.s_reset),
+                ("TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BUS_01", EnergySystems.s_reset),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_reset),
+                ("TST_BUS_03", EnergySystems.s_reset),
+                ("TST_TES_02", EnergySystems.s_reset),
+                ("TST_TES_01", EnergySystems.s_reset),
+                ("TST_SRC_01", EnergySystems.s_reset),
+                ("TST_DEM_02", EnergySystems.s_control),
+                ("TST_DEM_01", EnergySystems.s_control),
+                ("TST_BUS_02", EnergySystems.s_control),
+                ("TST_BUS_01", EnergySystems.s_control),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_control),
+                ("TST_BUS_03", EnergySystems.s_control),
+                ("TST_TES_02", EnergySystems.s_control),
+                ("TST_TES_01", EnergySystems.s_control),
+                ("TST_SRC_01", EnergySystems.s_control),
+                ("TST_DEM_02", EnergySystems.s_process),
+                ("TST_DEM_01", EnergySystems.s_process),
+                ("TST_BUS_02", EnergySystems.s_process),
+                ("TST_BUS_01", EnergySystems.s_process),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_process),
+                ("TST_BUS_03", EnergySystems.s_process),
+                ("TST_SRC_01", EnergySystems.s_process),
+                ("TST_TES_02", EnergySystems.s_process),
+                ("TST_TES_01", EnergySystems.s_process),
+                ("TST_TES_01", EnergySystems.s_load),
+                ("TST_TES_02", EnergySystems.s_load),
+                ("Proxy-TST_BUS_01|TST_BUS_03|TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_02", EnergySystems.s_distribute),
+                ("TST_BUS_01", EnergySystems.s_distribute),
+                ("TST_BUS_03", EnergySystems.s_distribute)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/order_of_operations/reorderings.jl
+++ b/test/order_of_operations/reorderings.jl
@@ -10,36 +10,34 @@ function test_data_input_priorities()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => [],
                 "output_order" => ["TST_BUS_03"],
-            )
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => [],
                 "output_order" => ["TST_BUS_03"],
-            )
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_02",
-                    "TST_BUS_01",
-                ],
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_02",
+                                  "TST_BUS_01"],
                 "output_order" => [],
-            )
+            ),
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -49,22 +47,18 @@ end
 
 function test_input_priorities_reordered_inputs()
     components, by_function = test_data_input_priorities()
-    steps = [
-        [100, ("TST_BUS_03", EnergySystems.s_control)],
-        [99, ("TST_BUS_01", EnergySystems.s_control)],
-        [98, ("TST_BUS_02", EnergySystems.s_control)],
-        [97, ("TST_BUS_03", EnergySystems.s_process)],
-        [96, ("TST_BUS_01", EnergySystems.s_process)],
-        [95, ("TST_BUS_02", EnergySystems.s_process)],
-    ]
-    expected = [
-        [100, ("TST_BUS_03", EnergySystems.s_control)],
-        [99, ("TST_BUS_01", EnergySystems.s_control)],
-        [98, ("TST_BUS_02", EnergySystems.s_control)],
-        [97, ("TST_BUS_03", EnergySystems.s_process)],
-        [96, ("TST_BUS_01", EnergySystems.s_process)],
-        [95, ("TST_BUS_02", EnergySystems.s_process)],
-    ]
+    steps = [[100, ("TST_BUS_03", EnergySystems.s_control)],
+             [99, ("TST_BUS_01", EnergySystems.s_control)],
+             [98, ("TST_BUS_02", EnergySystems.s_control)],
+             [97, ("TST_BUS_03", EnergySystems.s_process)],
+             [96, ("TST_BUS_01", EnergySystems.s_process)],
+             [95, ("TST_BUS_02", EnergySystems.s_process)]]
+    expected = [[100, ("TST_BUS_03", EnergySystems.s_control)],
+                [99, ("TST_BUS_01", EnergySystems.s_control)],
+                [98, ("TST_BUS_02", EnergySystems.s_control)],
+                [97, ("TST_BUS_03", EnergySystems.s_process)],
+                [96, ("TST_BUS_01", EnergySystems.s_process)],
+                [95, ("TST_BUS_02", EnergySystems.s_process)]]
     Resie.reorder_for_input_priorities(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -75,22 +69,18 @@ end
 
 function test_input_priorities_no_change()
     components, by_function = test_data_input_priorities()
-    steps = [
-        [100, ("TST_BUS_03", EnergySystems.s_control)],
-        [99, ("TST_BUS_02", EnergySystems.s_control)],
-        [98, ("TST_BUS_01", EnergySystems.s_control)],
-        [97, ("TST_BUS_03", EnergySystems.s_process)],
-        [96, ("TST_BUS_02", EnergySystems.s_process)],
-        [95, ("TST_BUS_01", EnergySystems.s_process)],
-    ]
-    expected = [
-        [100, ("TST_BUS_03", EnergySystems.s_control)],
-        [99, ("TST_BUS_02", EnergySystems.s_control)],
-        [98, ("TST_BUS_01", EnergySystems.s_control)],
-        [97, ("TST_BUS_03", EnergySystems.s_process)],
-        [96, ("TST_BUS_02", EnergySystems.s_process)],
-        [95, ("TST_BUS_01", EnergySystems.s_process)],
-    ]
+    steps = [[100, ("TST_BUS_03", EnergySystems.s_control)],
+             [99, ("TST_BUS_02", EnergySystems.s_control)],
+             [98, ("TST_BUS_01", EnergySystems.s_control)],
+             [97, ("TST_BUS_03", EnergySystems.s_process)],
+             [96, ("TST_BUS_02", EnergySystems.s_process)],
+             [95, ("TST_BUS_01", EnergySystems.s_process)]]
+    expected = [[100, ("TST_BUS_03", EnergySystems.s_control)],
+                [99, ("TST_BUS_02", EnergySystems.s_control)],
+                [98, ("TST_BUS_01", EnergySystems.s_control)],
+                [97, ("TST_BUS_03", EnergySystems.s_process)],
+                [96, ("TST_BUS_02", EnergySystems.s_process)],
+                [95, ("TST_BUS_01", EnergySystems.s_process)]]
     Resie.reorder_for_input_priorities(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -115,66 +105,60 @@ function test_data_busses_distribute()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => [
-                    "TST_BUS_04",
-                    "TST_BUS_03",
-                    "TST_BUS_02",
-                ],
-            )
+                "output_order" => ["TST_BUS_04",
+                                   "TST_BUS_03",
+                                   "TST_BUS_02"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                ],
-                "output_order" => [
-                    "TST_BUS_06",
-                    "TST_BUS_05",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01"],
+                "output_order" => ["TST_BUS_06",
+                                   "TST_BUS_05"],
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_03"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_06" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_03"],
                 "output_order" => [],
-            )
+            ),
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -184,22 +168,18 @@ end
 
 function test_busses_distribution_no_change()
     components, by_function = test_data_busses_distribute()
-    steps = [
-        [100, ("TST_BUS_04", EnergySystems.s_distribute)],
-        [99, ("TST_BUS_06", EnergySystems.s_distribute)],
-        [98, ("TST_BUS_05", EnergySystems.s_distribute)],
-        [97, ("TST_BUS_03", EnergySystems.s_distribute)],
-        [96, ("TST_BUS_02", EnergySystems.s_distribute)],
-        [95, ("TST_BUS_01", EnergySystems.s_distribute)],
-    ]
-    expected = [
-        [100, ("TST_BUS_04", EnergySystems.s_distribute)],
-        [99, ("TST_BUS_06", EnergySystems.s_distribute)],
-        [98, ("TST_BUS_05", EnergySystems.s_distribute)],
-        [97, ("TST_BUS_03", EnergySystems.s_distribute)],
-        [96, ("TST_BUS_02", EnergySystems.s_distribute)],
-        [95, ("TST_BUS_01", EnergySystems.s_distribute)],
-    ]
+    steps = [[100, ("TST_BUS_04", EnergySystems.s_distribute)],
+             [99, ("TST_BUS_06", EnergySystems.s_distribute)],
+             [98, ("TST_BUS_05", EnergySystems.s_distribute)],
+             [97, ("TST_BUS_03", EnergySystems.s_distribute)],
+             [96, ("TST_BUS_02", EnergySystems.s_distribute)],
+             [95, ("TST_BUS_01", EnergySystems.s_distribute)]]
+    expected = [[100, ("TST_BUS_04", EnergySystems.s_distribute)],
+                [99, ("TST_BUS_06", EnergySystems.s_distribute)],
+                [98, ("TST_BUS_05", EnergySystems.s_distribute)],
+                [97, ("TST_BUS_03", EnergySystems.s_distribute)],
+                [96, ("TST_BUS_02", EnergySystems.s_distribute)],
+                [95, ("TST_BUS_01", EnergySystems.s_distribute)]]
     Resie.reorder_distribution_of_busses(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -210,24 +190,24 @@ end
 
 function test_busses_distribution_reorder_steps()
     components, by_function = test_data_busses_distribute()
-    steps = [
-        [100, ("TST_BUS_01", EnergySystems.s_distribute)],
-        [99, ("TST_BUS_02", EnergySystems.s_distribute)],
-        [98, ("TST_BUS_03", EnergySystems.s_distribute)],
-        [97, ("Proxy-TST_BUS_01|TST_BUS_04|Proxy-TST_BUS_03|TST_BUS_05|TST_BUS_06|TST_BUS_02", EnergySystems.s_distribute)],
-        [96, ("TST_BUS_04", EnergySystems.s_distribute)],
-        [95, ("TST_BUS_05", EnergySystems.s_distribute)],
-        [94, ("TST_BUS_06", EnergySystems.s_distribute)],
-    ]
-    expected = [
-        [94, ("TST_BUS_01", EnergySystems.s_distribute)],
-        [95, ("TST_BUS_02", EnergySystems.s_distribute)],
-        [96, ("TST_BUS_03", EnergySystems.s_distribute)],
-        [97, ("Proxy-TST_BUS_01|TST_BUS_04|Proxy-TST_BUS_03|TST_BUS_05|TST_BUS_06|TST_BUS_02", EnergySystems.s_distribute)],
-        [93, ("TST_BUS_04", EnergySystems.s_distribute)],
-        [92, ("TST_BUS_05", EnergySystems.s_distribute)],
-        [91, ("TST_BUS_06", EnergySystems.s_distribute)],
-    ]
+    steps = [[100, ("TST_BUS_01", EnergySystems.s_distribute)],
+             [99, ("TST_BUS_02", EnergySystems.s_distribute)],
+             [98, ("TST_BUS_03", EnergySystems.s_distribute)],
+             [97,
+              ("Proxy-TST_BUS_01|TST_BUS_04|Proxy-TST_BUS_03|TST_BUS_05|TST_BUS_06|TST_BUS_02",
+               EnergySystems.s_distribute)],
+             [96, ("TST_BUS_04", EnergySystems.s_distribute)],
+             [95, ("TST_BUS_05", EnergySystems.s_distribute)],
+             [94, ("TST_BUS_06", EnergySystems.s_distribute)]]
+    expected = [[94, ("TST_BUS_01", EnergySystems.s_distribute)],
+                [95, ("TST_BUS_02", EnergySystems.s_distribute)],
+                [96, ("TST_BUS_03", EnergySystems.s_distribute)],
+                [97,
+                 ("Proxy-TST_BUS_01|TST_BUS_04|Proxy-TST_BUS_03|TST_BUS_05|TST_BUS_06|TST_BUS_02",
+                  EnergySystems.s_distribute)],
+                [93, ("TST_BUS_04", EnergySystems.s_distribute)],
+                [92, ("TST_BUS_05", EnergySystems.s_distribute)],
+                [91, ("TST_BUS_06", EnergySystems.s_distribute)]]
     Resie.reorder_distribution_of_busses(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -241,73 +221,55 @@ function test_data_storage_loading()
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BFT_01",
-                    "TST_BUS_03",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BFT_01",
+                                   "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_BFT_02"
-                ],
-                "output_order" => [
-                    "TST_BFT_02",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_BFT_02"],
+                "output_order" => ["TST_BFT_02"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BUS_01",
-                    "TST_BFT_03"
-                ],
-                "output_order" => [
-                    "TST_BFT_03",
-                ],
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BUS_01",
+                                  "TST_BFT_03"],
+                "output_order" => ["TST_BFT_03"],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_BFT_02" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_02"
-            ],
+            "output_refs" => ["TST_BUS_02"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_BFT_03" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_03"
-            ],
+            "output_refs" => ["TST_BUS_03"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -317,22 +279,18 @@ end
 
 function test_storage_loading_no_change()
     components, by_function = test_data_storage_loading()
-    steps = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_03", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [97, ("TST_BFT_02", EnergySystems.s_load)],
-        [96, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
-    expected = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_03", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [97, ("TST_BFT_02", EnergySystems.s_load)],
-        [96, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+             [99, ("TST_BFT_03", EnergySystems.s_process)],
+             [98, ("TST_BFT_02", EnergySystems.s_process)],
+             [97, ("TST_BFT_02", EnergySystems.s_load)],
+             [96, ("TST_BFT_01", EnergySystems.s_load)],
+             [95, ("TST_BFT_03", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+                [99, ("TST_BFT_03", EnergySystems.s_process)],
+                [98, ("TST_BFT_02", EnergySystems.s_process)],
+                [97, ("TST_BFT_02", EnergySystems.s_load)],
+                [96, ("TST_BFT_01", EnergySystems.s_load)],
+                [95, ("TST_BFT_03", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -343,66 +301,54 @@ end
 
 function test_storage_loading_reorder_steps_1()
     components, by_function = test_data_storage_loading()
-    steps = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_03", EnergySystems.s_process)],
-        [97, ("TST_BFT_01", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
-    expected = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_03", EnergySystems.s_process)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [94, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+             [99, ("TST_BFT_02", EnergySystems.s_process)],
+             [98, ("TST_BFT_03", EnergySystems.s_process)],
+             [97, ("TST_BFT_01", EnergySystems.s_load)],
+             [96, ("TST_BFT_02", EnergySystems.s_load)],
+             [95, ("TST_BFT_03", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+                [99, ("TST_BFT_02", EnergySystems.s_process)],
+                [98, ("TST_BFT_03", EnergySystems.s_process)],
+                [95, ("TST_BFT_01", EnergySystems.s_load)],
+                [96, ("TST_BFT_02", EnergySystems.s_load)],
+                [94, ("TST_BFT_03", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
 
 function test_storage_loading_reorder_steps_2()
     components, by_function = test_data_storage_loading()
-    steps = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_01", EnergySystems.s_process)],
-        [97, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-    ]
-    expected = [
-		[100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_01", EnergySystems.s_process)],
-        [94, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+             [99, ("TST_BFT_02", EnergySystems.s_process)],
+             [98, ("TST_BFT_01", EnergySystems.s_process)],
+             [97, ("TST_BFT_03", EnergySystems.s_load)],
+             [96, ("TST_BFT_02", EnergySystems.s_load)],
+             [95, ("TST_BFT_01", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+                [99, ("TST_BFT_02", EnergySystems.s_process)],
+                [98, ("TST_BFT_01", EnergySystems.s_process)],
+                [94, ("TST_BFT_03", EnergySystems.s_load)],
+                [96, ("TST_BFT_02", EnergySystems.s_load)],
+                [95, ("TST_BFT_01", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
 
 function test_storage_loading_reorder_steps_3()
     components, by_function = test_data_storage_loading()
-    steps = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_01", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [97, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_02", EnergySystems.s_load)],
-    ]
-    expected = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_01", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [93, ("TST_BFT_03", EnergySystems.s_load)],
-        [94, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_02", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+             [99, ("TST_BFT_01", EnergySystems.s_process)],
+             [98, ("TST_BFT_02", EnergySystems.s_process)],
+             [97, ("TST_BFT_03", EnergySystems.s_load)],
+             [96, ("TST_BFT_01", EnergySystems.s_load)],
+             [95, ("TST_BFT_02", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+                [99, ("TST_BFT_01", EnergySystems.s_process)],
+                [98, ("TST_BFT_02", EnergySystems.s_process)],
+                [93, ("TST_BFT_03", EnergySystems.s_load)],
+                [94, ("TST_BFT_01", EnergySystems.s_load)],
+                [95, ("TST_BFT_02", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
@@ -420,90 +366,66 @@ function test_data_storage_loading_with_matrix()
             "medium" => "m_h_w_ht1",
             "output_refs" => ["TST_BUS_01"],
             "is_source" => true,
-        ),   
+        ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_BUS_02",
-                    "TST_BFT_01",
-                    "TST_BUS_03",
-                ],
-                "energy_flow" => [
-                    [1, 0, 1],
-                    [1, 0, 1]
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_BUS_02",
+                                   "TST_BFT_01",
+                                   "TST_BUS_03"],
+                "energy_flow" => [[1, 0, 1],
+                                  [1, 0, 1]],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_02",
-                    "TST_BUS_01"
-                ],
-                "output_order" => [
-                    "TST_BFT_02"
-                ],
-                "energy_flow" => [
-                    [0],
-                    [0]
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_02",
+                                  "TST_BUS_01"],
+                "output_order" => ["TST_BFT_02"],
+                "energy_flow" => [[0],
+                                  [0]],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_BFT_03",
-                    "TST_BUS_01"
-                ],
-                "output_order" => [
-                    "TST_BFT_03"
-                ],
-                "energy_flow" => [
-                    [0],
-                    [1]
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_BFT_03",
+                                  "TST_BUS_01"],
+                "output_order" => ["TST_BFT_03"],
+                "energy_flow" => [[0],
+                                  [1]],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_BFT_02" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_02"
-            ],
+            "output_refs" => ["TST_BUS_02"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_BFT_03" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_03"
-            ],
+            "output_refs" => ["TST_BUS_03"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -513,66 +435,54 @@ end
 
 function test_storage_loading_reorder_steps_with_matrix_1()
     components, by_function = test_data_storage_loading_with_matrix()
-    steps = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_03", EnergySystems.s_process)],
-        [97, ("TST_BFT_01", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
-    expected = [
-        [100, ("TST_BFT_01", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_03", EnergySystems.s_process)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [94, ("TST_BFT_03", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+             [99, ("TST_BFT_02", EnergySystems.s_process)],
+             [98, ("TST_BFT_03", EnergySystems.s_process)],
+             [97, ("TST_BFT_01", EnergySystems.s_load)],
+             [96, ("TST_BFT_02", EnergySystems.s_load)],
+             [95, ("TST_BFT_03", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_01", EnergySystems.s_process)],
+                [99, ("TST_BFT_02", EnergySystems.s_process)],
+                [98, ("TST_BFT_03", EnergySystems.s_process)],
+                [95, ("TST_BFT_01", EnergySystems.s_load)],
+                [96, ("TST_BFT_02", EnergySystems.s_load)],
+                [94, ("TST_BFT_03", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
 
 function test_storage_loading_reorder_steps_with_matrix_2()
     components, by_function = test_data_storage_loading_with_matrix()
-    steps = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_01", EnergySystems.s_process)],
-        [97, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-    ]
-    expected = [
-		[100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_02", EnergySystems.s_process)],
-        [98, ("TST_BFT_01", EnergySystems.s_process)],
-        [94, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_02", EnergySystems.s_load)],
-        [95, ("TST_BFT_01", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+             [99, ("TST_BFT_02", EnergySystems.s_process)],
+             [98, ("TST_BFT_01", EnergySystems.s_process)],
+             [97, ("TST_BFT_03", EnergySystems.s_load)],
+             [96, ("TST_BFT_02", EnergySystems.s_load)],
+             [95, ("TST_BFT_01", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+                [99, ("TST_BFT_02", EnergySystems.s_process)],
+                [98, ("TST_BFT_01", EnergySystems.s_process)],
+                [94, ("TST_BFT_03", EnergySystems.s_load)],
+                [96, ("TST_BFT_02", EnergySystems.s_load)],
+                [95, ("TST_BFT_01", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end
 
 function test_storage_loading_reorder_steps_with_matrix_3()
     components, by_function = test_data_storage_loading_with_matrix()
-    steps = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_01", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [97, ("TST_BFT_03", EnergySystems.s_load)],
-        [96, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_02", EnergySystems.s_load)],
-    ]
-    expected = [
-        [100, ("TST_BFT_03", EnergySystems.s_process)],
-        [99, ("TST_BFT_01", EnergySystems.s_process)],
-        [98, ("TST_BFT_02", EnergySystems.s_process)],
-        [93, ("TST_BFT_03", EnergySystems.s_load)],
-        [94, ("TST_BFT_01", EnergySystems.s_load)],
-        [95, ("TST_BFT_02", EnergySystems.s_load)],
-    ]
+    steps = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+             [99, ("TST_BFT_01", EnergySystems.s_process)],
+             [98, ("TST_BFT_02", EnergySystems.s_process)],
+             [97, ("TST_BFT_03", EnergySystems.s_load)],
+             [96, ("TST_BFT_01", EnergySystems.s_load)],
+             [95, ("TST_BFT_02", EnergySystems.s_load)]]
+    expected = [[100, ("TST_BFT_03", EnergySystems.s_process)],
+                [99, ("TST_BFT_01", EnergySystems.s_process)],
+                [98, ("TST_BFT_02", EnergySystems.s_process)],
+                [93, ("TST_BFT_03", EnergySystems.s_load)],
+                [94, ("TST_BFT_01", EnergySystems.s_load)],
+                [95, ("TST_BFT_02", EnergySystems.s_load)]]
     Resie.reorder_storage_loading(steps, components, by_function)
     @test pwc_steps_astr(expected, steps) == ""
 end

--- a/test/order_of_operations/storage_loading_switch.jl
+++ b/test/order_of_operations/storage_loading_switch.jl
@@ -22,48 +22,36 @@ function test_ooo_storage_loading_switch()
         "TST_GBO_01" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "power_th" => 40000,
             "efficiency_fuel_in" => "const:1.0",
         ),
         "TST_GBO_02" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "power_th" => 40000,
             "efficiency_fuel_in" => "const:1.0",
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
-                "input_order" => [
-                    "TST_GBO_01",
-                    "TST_BFT_01",
-                    "TST_GBO_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_01",
-                    "TST_BFT_01"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 0],
-                    [1, 0]
-                ]
-            )
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_GBO_01",
+                                  "TST_BFT_01",
+                                  "TST_GBO_02"],
+                "output_order" => ["TST_DEM_01",
+                                   "TST_BFT_01"],
+                "energy_flow" => [[1, 1],
+                                  [1, 0],
+                                  [1, 0]],
+            ),
         ),
         "TST_BFT_01" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "capacity" => 40000,
-            "load" => 0
+            "load" => 0,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
@@ -71,42 +59,40 @@ function test_ooo_storage_loading_switch()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1000
+            "scale" => 1000,
         ),
     )
 
-    expected = [
-        ("TST_DEM_01", EnergySystems.s_reset),
-        ("TST_BUS_01", EnergySystems.s_reset),
-        ("TST_GBO_02", EnergySystems.s_reset),
-        ("TST_GBO_01", EnergySystems.s_reset),
-        ("TST_BFT_01", EnergySystems.s_reset),
-        ("TST_GRI_02", EnergySystems.s_reset),
-        ("TST_GRI_01", EnergySystems.s_reset),
-        ("TST_DEM_01", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        ("TST_GBO_02", EnergySystems.s_control),
-        ("TST_GBO_01", EnergySystems.s_control),
-        ("TST_BFT_01", EnergySystems.s_control),
-        ("TST_GRI_02", EnergySystems.s_control),
-        ("TST_GRI_01", EnergySystems.s_control),
-        ("TST_DEM_01", EnergySystems.s_process),
-        ("TST_BUS_01", EnergySystems.s_process),
-        ("TST_GBO_01", EnergySystems.s_potential),
-        ("TST_GBO_02", EnergySystems.s_potential),
-        ("TST_GBO_01", EnergySystems.s_process),
-        ("TST_BFT_01", EnergySystems.s_process),
-        ("TST_GBO_02", EnergySystems.s_process),
-        ("TST_BFT_01", EnergySystems.s_load),
-        ("TST_GRI_02", EnergySystems.s_process),
-        ("TST_GRI_01", EnergySystems.s_process),
-        ("TST_BUS_01", EnergySystems.s_distribute),
-    ]
+    expected = [("TST_DEM_01", EnergySystems.s_reset),
+                ("TST_BUS_01", EnergySystems.s_reset),
+                ("TST_GBO_02", EnergySystems.s_reset),
+                ("TST_GBO_01", EnergySystems.s_reset),
+                ("TST_BFT_01", EnergySystems.s_reset),
+                ("TST_GRI_02", EnergySystems.s_reset),
+                ("TST_GRI_01", EnergySystems.s_reset),
+                ("TST_DEM_01", EnergySystems.s_control),
+                ("TST_BUS_01", EnergySystems.s_control),
+                ("TST_GBO_02", EnergySystems.s_control),
+                ("TST_GBO_01", EnergySystems.s_control),
+                ("TST_BFT_01", EnergySystems.s_control),
+                ("TST_GRI_02", EnergySystems.s_control),
+                ("TST_GRI_01", EnergySystems.s_control),
+                ("TST_DEM_01", EnergySystems.s_process),
+                ("TST_BUS_01", EnergySystems.s_process),
+                ("TST_GBO_01", EnergySystems.s_potential),
+                ("TST_GBO_02", EnergySystems.s_potential),
+                ("TST_GBO_01", EnergySystems.s_process),
+                ("TST_BFT_01", EnergySystems.s_process),
+                ("TST_GBO_02", EnergySystems.s_process),
+                ("TST_BFT_01", EnergySystems.s_load),
+                ("TST_GRI_02", EnergySystems.s_process),
+                ("TST_GRI_01", EnergySystems.s_process),
+                ("TST_BUS_01", EnergySystems.s_distribute)]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/order_of_operations/transformer_chains_ooo.jl
+++ b/test/order_of_operations/transformer_chains_ooo.jl
@@ -9,11 +9,9 @@ function test_base_order()
     components_config = Dict{String,Any}(
         "TST_01_ELT_01_PVP" => Dict{String,Any}(
             "type" => "PVPlant",
-            "output_refs" => [
-                "TST_01_ELT_01_BUS"
-            ],
+            "output_refs" => ["TST_01_ELT_01_BUS"],
             "energy_profile_file_path" => "./profiles/tests/source_power_pv.prf",
-            "scale" => 20000
+            "scale" => 20000,
         ),
         "TST_01_HZG_01_DEM" => Dict{String,Any}(
             "type" => "Demand",
@@ -21,194 +19,164 @@ function test_base_order()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 10000.0
+            "scale" => 10000.0,
         ),
         "TST_01_ELT_01_DEM" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_e_ac_230v",
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
-            "scale" => 15000
+            "scale" => 15000,
         ),
         "TST_01_HZG_01_BUS" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_HZG_01_CHP",
-                    "TST_01_HZG_01_HTP",
-                    "TST_01_HZG_01_BFT"
-                ],
-                "output_order" => [
-                    "TST_01_HZG_01_DEM",
-                    "TST_01_HZG_01_BFT"
-                ]
-            )
+                "input_order" => ["TST_01_HZG_01_CHP",
+                                  "TST_01_HZG_01_HTP",
+                                  "TST_01_HZG_01_BFT"],
+                "output_order" => ["TST_01_HZG_01_DEM",
+                                   "TST_01_HZG_01_BFT"],
+            ),
         ),
         "TST_01_ELT_01_BUS" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_ELT_01_PVP",
-                    "TST_01_HZG_01_CHP",
-                    "TST_01_ELT_01_BAT",
-                    "TST_01_ELT_01_GRI"
-                ],
-                "output_order" => [
-                    "TST_01_ELT_01_DEM",
-                    "TST_01_HZG_01_HTP",
-                    "TST_01_ELT_01_BAT",
-                    "TST_01_ELT_01_GRO"
-                ]
-            )
+                "input_order" => ["TST_01_ELT_01_PVP",
+                                  "TST_01_HZG_01_CHP",
+                                  "TST_01_ELT_01_BAT",
+                                  "TST_01_ELT_01_GRI"],
+                "output_order" => ["TST_01_ELT_01_DEM",
+                                   "TST_01_HZG_01_HTP",
+                                   "TST_01_ELT_01_BAT",
+                                   "TST_01_ELT_01_GRO"],
+            ),
         ),
         "TST_01_HZG_01_CHP" => Dict{String,Any}(
             "type" => "CHPP",
-            "output_refs" => [
-                "TST_01_HZG_01_BUS",
-                "TST_01_ELT_01_BUS"
-            ],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "storage_driven",
-                    "storage_uac" => "TST_01_HZG_01_BFT",
-                    "high_threshold" => 0.9,
-                    "low_threshold" => 0.2
-                )
-            ],
-            "power_el" => 12500
+            "output_refs" => ["TST_01_HZG_01_BUS",
+                              "TST_01_ELT_01_BUS"],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "storage_driven",
+                                      "storage_uac" => "TST_01_HZG_01_BFT",
+                                      "high_threshold" => 0.9,
+                                      "low_threshold" => 0.2,
+                                  )],
+            "power_el" => 12500,
         ),
         "TST_01_HZG_01_HTP" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_01_HZG_01_BUS"
-            ],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "storage_driven",
-                    "storage_uac" => "TST_01_HZG_01_BFT",
-                    "high_threshold" => 0.9,
-                    "low_threshold" => 0.2
-                )
-            ],
+            "output_refs" => ["TST_01_HZG_01_BUS"],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "storage_driven",
+                                      "storage_uac" => "TST_01_HZG_01_BFT",
+                                      "high_threshold" => 0.9,
+                                      "low_threshold" => 0.2,
+                                  )],
             "power_th" => 20000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
         "TST_01_HZG_01_BFT" => Dict{String,Any}(
             "type" => "BufferTank",
-            "output_refs" => [
-                "TST_01_HZG_01_BUS"
-            ],
+            "output_refs" => ["TST_01_HZG_01_BUS"],
             "capacity" => 40000,
-            "load" => 20000
+            "load" => 20000,
         ),
         "TST_01_ELT_01_BAT" => Dict{String,Any}(
             "type" => "Battery",
-            "output_refs" => [
-                "TST_01_ELT_01_BUS"
-            ],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "economical_discharge",
-                    "pv_plant_uac" => "TST_01_ELT_01_PVP",
-                    "battery_uac" => "TST_01_ELT_01_BAT",
-                    "pv_threshold" => 0.15,
-                    "min_charge" => 0.2,
-                    "discharge_limit" => 0.05
-                ),
-            ],
+            "output_refs" => ["TST_01_ELT_01_BUS"],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "economical_discharge",
+                                      "pv_plant_uac" => "TST_01_ELT_01_PVP",
+                                      "battery_uac" => "TST_01_ELT_01_BAT",
+                                      "pv_threshold" => 0.15,
+                                      "min_charge" => 0.2,
+                                      "discharge_limit" => 0.05,
+                                  )],
             "capacity" => 10000,
-            "load" => 5000
+            "load" => 5000,
         ),
         "TST_01_HZG_01_GRI" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_natgas",
-            "output_refs" => [
-                "TST_01_HZG_01_CHP"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_01_HZG_01_CHP"],
+            "is_source" => true,
         ),
         "TST_01_HZG_02_SRC" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_01_HZG_01_HTP"
-            ],
+            "output_refs" => ["TST_01_HZG_01_HTP"],
             "max_power_profile_file_path" => "./profiles/tests/source_heat_max_power.prf",
             "temperature_profile_file_path" => "./profiles/tests/source_heat_temperature.prf",
-            "scale" => 25000
+            "scale" => 25000,
         ),
         "TST_01_ELT_01_GRI" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_01_ELT_01_BUS"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_01_ELT_01_BUS"],
+            "is_source" => true,
         ),
         "TST_01_ELT_01_GRO" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
             "output_refs" => [],
-            "is_source" => false
-        )
+            "is_source" => false,
+        ),
     )
 
-    expected = [
-        [1300, ("TST_01_ELT_01_PVP", EnergySystems.s_reset)],
-        [1299, ("TST_01_ELT_01_DEM", EnergySystems.s_reset)],
-        [1298, ("TST_01_HZG_01_DEM", EnergySystems.s_reset)],
-        [1297, ("TST_01_ELT_01_BUS", EnergySystems.s_reset)],
-        [1296, ("TST_01_HZG_01_BUS", EnergySystems.s_reset)],
-        [1295, ("TST_01_HZG_01_CHP", EnergySystems.s_reset)],
-        [1294, ("TST_01_HZG_01_HTP", EnergySystems.s_reset)],
-        [1293, ("TST_01_HZG_01_BFT", EnergySystems.s_reset)],
-        [1292, ("TST_01_ELT_01_BAT", EnergySystems.s_reset)],
-        [1291, ("TST_01_ELT_01_GRI", EnergySystems.s_reset)],
-        [1290, ("TST_01_HZG_01_GRI", EnergySystems.s_reset)],
-        [1289, ("TST_01_HZG_02_SRC", EnergySystems.s_reset)],
-        [1288, ("TST_01_ELT_01_GRO", EnergySystems.s_reset)],
-        [1287, ("TST_01_ELT_01_PVP", EnergySystems.s_control)],
-        [1286, ("TST_01_ELT_01_DEM", EnergySystems.s_control)],
-        [1285, ("TST_01_HZG_01_DEM", EnergySystems.s_control)],
-        [1284, ("TST_01_ELT_01_BUS", EnergySystems.s_control)],
-        [1283, ("TST_01_HZG_01_BUS", EnergySystems.s_control)],
-        [1282, ("TST_01_HZG_01_CHP", EnergySystems.s_control)],
-        [1281, ("TST_01_HZG_01_HTP", EnergySystems.s_control)],
-        [1280, ("TST_01_HZG_01_BFT", EnergySystems.s_control)],
-        [1279, ("TST_01_ELT_01_BAT", EnergySystems.s_control)],
-        [1278, ("TST_01_ELT_01_GRI", EnergySystems.s_control)],
-        [1277, ("TST_01_HZG_01_GRI", EnergySystems.s_control)],
-        [1276, ("TST_01_HZG_02_SRC", EnergySystems.s_control)],
-        [1275, ("TST_01_ELT_01_GRO", EnergySystems.s_control)],
-        [1274, ("TST_01_ELT_01_PVP", EnergySystems.s_process)],
-        [1273, ("TST_01_ELT_01_DEM", EnergySystems.s_process)],
-        [1272, ("TST_01_HZG_01_DEM", EnergySystems.s_process)],
-        [1271, ("TST_01_ELT_01_BUS", EnergySystems.s_process)],
-        [1270, ("TST_01_HZG_01_BUS", EnergySystems.s_process)],
-        [1269, ("TST_01_HZG_01_CHP", EnergySystems.s_potential)],
-        [1268, ("TST_01_HZG_01_HTP", EnergySystems.s_potential)],
-        [1267, ("TST_01_HZG_01_CHP", EnergySystems.s_process)],
-        [1266, ("TST_01_HZG_01_HTP", EnergySystems.s_process)],
-        [1265, ("TST_01_HZG_01_BFT", EnergySystems.s_process)],
-        [1264, ("TST_01_ELT_01_BAT", EnergySystems.s_process)],
-        [1263, ("TST_01_HZG_01_BFT", EnergySystems.s_load)],
-        [1262, ("TST_01_ELT_01_BAT", EnergySystems.s_load)],
-        [1261, ("TST_01_ELT_01_GRI", EnergySystems.s_process)],
-        [1260, ("TST_01_HZG_01_GRI", EnergySystems.s_process)],
-        [1259, ("TST_01_HZG_02_SRC", EnergySystems.s_process)],
-        [1258, ("TST_01_ELT_01_GRO", EnergySystems.s_process)],
-        [1257, ("TST_01_ELT_01_BUS", EnergySystems.s_distribute)],
-        [1256, ("TST_01_HZG_01_BUS", EnergySystems.s_distribute)],
-    ]
+    expected = [[1300, ("TST_01_ELT_01_PVP", EnergySystems.s_reset)],
+                [1299, ("TST_01_ELT_01_DEM", EnergySystems.s_reset)],
+                [1298, ("TST_01_HZG_01_DEM", EnergySystems.s_reset)],
+                [1297, ("TST_01_ELT_01_BUS", EnergySystems.s_reset)],
+                [1296, ("TST_01_HZG_01_BUS", EnergySystems.s_reset)],
+                [1295, ("TST_01_HZG_01_CHP", EnergySystems.s_reset)],
+                [1294, ("TST_01_HZG_01_HTP", EnergySystems.s_reset)],
+                [1293, ("TST_01_HZG_01_BFT", EnergySystems.s_reset)],
+                [1292, ("TST_01_ELT_01_BAT", EnergySystems.s_reset)],
+                [1291, ("TST_01_ELT_01_GRI", EnergySystems.s_reset)],
+                [1290, ("TST_01_HZG_01_GRI", EnergySystems.s_reset)],
+                [1289, ("TST_01_HZG_02_SRC", EnergySystems.s_reset)],
+                [1288, ("TST_01_ELT_01_GRO", EnergySystems.s_reset)],
+                [1287, ("TST_01_ELT_01_PVP", EnergySystems.s_control)],
+                [1286, ("TST_01_ELT_01_DEM", EnergySystems.s_control)],
+                [1285, ("TST_01_HZG_01_DEM", EnergySystems.s_control)],
+                [1284, ("TST_01_ELT_01_BUS", EnergySystems.s_control)],
+                [1283, ("TST_01_HZG_01_BUS", EnergySystems.s_control)],
+                [1282, ("TST_01_HZG_01_CHP", EnergySystems.s_control)],
+                [1281, ("TST_01_HZG_01_HTP", EnergySystems.s_control)],
+                [1280, ("TST_01_HZG_01_BFT", EnergySystems.s_control)],
+                [1279, ("TST_01_ELT_01_BAT", EnergySystems.s_control)],
+                [1278, ("TST_01_ELT_01_GRI", EnergySystems.s_control)],
+                [1277, ("TST_01_HZG_01_GRI", EnergySystems.s_control)],
+                [1276, ("TST_01_HZG_02_SRC", EnergySystems.s_control)],
+                [1275, ("TST_01_ELT_01_GRO", EnergySystems.s_control)],
+                [1274, ("TST_01_ELT_01_PVP", EnergySystems.s_process)],
+                [1273, ("TST_01_ELT_01_DEM", EnergySystems.s_process)],
+                [1272, ("TST_01_HZG_01_DEM", EnergySystems.s_process)],
+                [1271, ("TST_01_ELT_01_BUS", EnergySystems.s_process)],
+                [1270, ("TST_01_HZG_01_BUS", EnergySystems.s_process)],
+                [1269, ("TST_01_HZG_01_CHP", EnergySystems.s_potential)],
+                [1268, ("TST_01_HZG_01_HTP", EnergySystems.s_potential)],
+                [1267, ("TST_01_HZG_01_CHP", EnergySystems.s_process)],
+                [1266, ("TST_01_HZG_01_HTP", EnergySystems.s_process)],
+                [1265, ("TST_01_HZG_01_BFT", EnergySystems.s_process)],
+                [1264, ("TST_01_ELT_01_BAT", EnergySystems.s_process)],
+                [1263, ("TST_01_HZG_01_BFT", EnergySystems.s_load)],
+                [1262, ("TST_01_ELT_01_BAT", EnergySystems.s_load)],
+                [1261, ("TST_01_ELT_01_GRI", EnergySystems.s_process)],
+                [1260, ("TST_01_HZG_01_GRI", EnergySystems.s_process)],
+                [1259, ("TST_01_HZG_02_SRC", EnergySystems.s_process)],
+                [1258, ("TST_01_ELT_01_GRO", EnergySystems.s_process)],
+                [1257, ("TST_01_ELT_01_BUS", EnergySystems.s_distribute)],
+                [1256, ("TST_01_HZG_01_BUS", EnergySystems.s_distribute)]]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     by_function = Resie.categorize_by_function(components)
     steps = Resie.base_order(by_function)
@@ -227,7 +195,7 @@ function test_ooo_middle_bus()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -235,228 +203,192 @@ function test_ooo_middle_bus()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_02" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_03"
-            ],
+            "output_refs" => ["TST_HP_03"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_GRI_EL" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 1200,
             "output_temperature" => 10,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
             "output_temperature" => 25,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 1200,
             "output_temperature" => 20,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
             "output_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_06"
-            ],
+            "output_refs" => ["TST_HP_06"],
             "power_th" => 1200,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_06" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_01"
-            ],
+            "output_refs" => ["TST_DEM_01"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_07" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_08"
-            ],
+            "output_refs" => ["TST_HP_08"],
             "power_th" => 1200,
             "output_temperature" => 70,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_08" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_EL"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05",
-                    "TST_HP_06",
-                    "TST_HP_07",
-                    "TST_HP_08"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_EL"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05",
+                                   "TST_HP_06",
+                                   "TST_HP_07",
+                                   "TST_HP_08"],
+                "energy_flow" => [[1, 1, 1, 1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_HP_04"
-                ],
-                "output_order" => [
-                    "TST_HP_07",
-                    "TST_HP_05"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_02",
+                                  "TST_HP_04"],
+                "output_order" => ["TST_HP_07",
+                                   "TST_HP_05"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_06 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_08 s_reset",
-        "TST_HP_07 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_SRC_02 s_reset",
-        "TST_GRI_EL s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_06 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_08 s_control",
-        "TST_HP_07 s_control",
-        "TST_SRC_01 s_control",
-        "TST_SRC_02 s_control",
-        "TST_GRI_EL s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_08 s_potential",
-        "TST_HP_07 s_potential",
-        "TST_HP_06 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_02 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_04 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_07 s_process",
-        "TST_HP_08 s_process",
-        "TST_HP_05 s_process",
-        "TST_HP_06 s_process",
-        "TST_SRC_01 s_process",
-        "TST_SRC_02 s_process",
-        "TST_GRI_EL s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_06 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_08 s_reset",
+                "TST_HP_07 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_SRC_02 s_reset",
+                "TST_GRI_EL s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_06 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_08 s_control",
+                "TST_HP_07 s_control",
+                "TST_SRC_01 s_control",
+                "TST_SRC_02 s_control",
+                "TST_GRI_EL s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_08 s_potential",
+                "TST_HP_07 s_potential",
+                "TST_HP_06 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_02 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_04 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_07 s_process",
+                "TST_HP_08 s_process",
+                "TST_HP_05 s_process",
+                "TST_HP_06 s_process",
+                "TST_SRC_01 s_process",
+                "TST_SRC_02 s_process",
+                "TST_GRI_EL s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -474,7 +406,7 @@ function test_ooo_middle_bus_different_order()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -482,228 +414,192 @@ function test_ooo_middle_bus_different_order()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_02" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_03"
-            ],
+            "output_refs" => ["TST_HP_03"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_GRI_EL" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 1200,
             "output_temperature" => 10,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
             "output_temperature" => 25,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 1200,
             "output_temperature" => 20,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
             "output_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_06"
-            ],
+            "output_refs" => ["TST_HP_06"],
             "power_th" => 1200,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_06" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_01"
-            ],
+            "output_refs" => ["TST_DEM_01"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_07" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_08"
-            ],
+            "output_refs" => ["TST_HP_08"],
             "power_th" => 1200,
             "output_temperature" => 70,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_08" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_EL"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05",
-                    "TST_HP_06",
-                    "TST_HP_07",
-                    "TST_HP_08"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_EL"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05",
+                                   "TST_HP_06",
+                                   "TST_HP_07",
+                                   "TST_HP_08"],
+                "energy_flow" => [[1, 1, 1, 1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_04",
-                    "TST_HP_02"
-                ],
-                "output_order" => [
-                    "TST_HP_05",
-                    "TST_HP_07"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_04",
+                                  "TST_HP_02"],
+                "output_order" => ["TST_HP_05",
+                                   "TST_HP_07"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_06 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_08 s_reset",
-        "TST_HP_07 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_SRC_02 s_reset",
-        "TST_GRI_EL s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_06 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_08 s_control",
-        "TST_HP_07 s_control",
-        "TST_SRC_01 s_control",
-        "TST_SRC_02 s_control",
-        "TST_GRI_EL s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_06 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_08 s_potential",
-        "TST_HP_07 s_potential",
-        "TST_HP_04 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_02 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_05 s_process",
-        "TST_HP_06 s_process",
-        "TST_HP_07 s_process",
-        "TST_HP_08 s_process",
-        "TST_SRC_01 s_process",
-        "TST_SRC_02 s_process",
-        "TST_GRI_EL s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_06 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_08 s_reset",
+                "TST_HP_07 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_SRC_02 s_reset",
+                "TST_GRI_EL s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_06 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_08 s_control",
+                "TST_HP_07 s_control",
+                "TST_SRC_01 s_control",
+                "TST_SRC_02 s_control",
+                "TST_GRI_EL s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_06 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_08 s_potential",
+                "TST_HP_07 s_potential",
+                "TST_HP_04 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_02 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_05 s_process",
+                "TST_HP_06 s_process",
+                "TST_HP_07 s_process",
+                "TST_HP_08 s_process",
+                "TST_SRC_01 s_process",
+                "TST_SRC_02 s_process",
+                "TST_GRI_EL s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -721,7 +617,7 @@ function test_ooo_middle_transformer()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -729,56 +625,44 @@ function test_ooo_middle_transformer()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 90,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_GRI_O2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_o2",
-            "input_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 20
+            "constant_temperature" => 20,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 9000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_01_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_HP_02",
-                "TST_BUS_H2",
-                "TST_GRI_O2"
-            ],
+            "output_refs" => ["TST_HP_02",
+                              "TST_BUS_H2",
+                              "TST_GRI_O2"],
             "m_heat_ht_out" => "m_h_w_lt1",
             "output_temperature" => 45,
             "power_el" => 40000,
@@ -786,118 +670,96 @@ function test_ooo_middle_transformer()
             "nr_switchable_units" => 4,
             "dispatch_strategy" => "equal_with_mpf",
             "min_power_fraction_total" => 0.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "ESS_FBH2_01" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "min_power_fraction" => 0,
-            "power_th" => 1500
+            "power_th" => 1500,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_01_ELY_01"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_01_ELY_01"],
+                "energy_flow" => [[1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_HP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1],
-                    [1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_HP_02",
+                                  "TST_HP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 1, 1]],
+            ),
         ),
         "TST_BUS_H2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_c_g_h2",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_ELY_01"
-                ],
-                "output_order" => [
-                    "ESS_FBH2_01"
-                ],
-                "energy_flow" => [
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_01_ELY_01"],
+                "output_order" => ["ESS_FBH2_01"],
+                "energy_flow" => [[1]],
+            ),
+        ),
     )
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_H2 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_01_ELY_01 s_reset",
-        "TST_HP_02 s_reset",
-        "ESS_FBH2_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_O2 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_H2 s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_01_ELY_01 s_control",
-        "TST_HP_02 s_control",
-        "ESS_FBH2_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_O2 s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_H2 s_process",
-        "TST_BUS_EL s_process",
-        "ESS_FBH2_01 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_01_ELY_01 s_process",
-        "ESS_FBH2_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_HP_01 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_O2 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_H2 s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_H2 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_01_ELY_01 s_reset",
+                "TST_HP_02 s_reset",
+                "ESS_FBH2_01 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_O2 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_H2 s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_01_ELY_01 s_control",
+                "TST_HP_02 s_control",
+                "ESS_FBH2_01 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_O2 s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_H2 s_process",
+                "TST_BUS_EL s_process",
+                "ESS_FBH2_01 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_01_ELY_01 s_process",
+                "ESS_FBH2_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_HP_01 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_O2 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_H2 s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -915,185 +777,151 @@ function test_ooo_parallels()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_TH1"
-            ],
+            "output_refs" => ["TST_BUS_TH1"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 500,
             "output_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 500,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 600,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 1500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05"],
+                "energy_flow" => [[1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH1" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_03",
-                    "TST_HP_05"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_03",
+                                   "TST_HP_05"],
+                "energy_flow" => [[1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_HP_04",
-                    "TST_HP_05"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_02",
+                                  "TST_HP_04",
+                                  "TST_HP_05"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1],
+                                  [1]],
+            ),
+        ),
     )
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH2 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_BUS_TH1 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH2 s_control",
-        "TST_BUS_EL s_control",
-        "TST_BUS_TH1 s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH2 s_process",
-        "TST_BUS_EL s_process",
-        "TST_BUS_TH1 s_process",
-        "TST_HP_02 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_04 s_process",
-        "TST_HP_05 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_BUS_TH2 s_distribute",
-        "TST_BUS_EL s_distribute",
-        "TST_BUS_TH1 s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH2 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_BUS_TH1 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH2 s_control",
+                "TST_BUS_EL s_control",
+                "TST_BUS_TH1 s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH2 s_process",
+                "TST_BUS_EL s_process",
+                "TST_BUS_TH1 s_process",
+                "TST_HP_02 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_04 s_process",
+                "TST_HP_05 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_BUS_TH2 s_distribute",
+                "TST_BUS_EL s_distribute",
+                "TST_BUS_TH1 s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -1111,184 +939,150 @@ function test_ooo_parallels_different_order()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_TH1"
-            ],
+            "output_refs" => ["TST_BUS_TH1"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 500,
             "output_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 500,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 600,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 1500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05"],
+                "energy_flow" => [[1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH1" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_HP_03",
-                    "TST_HP_05",
-                    "TST_HP_01"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_HP_03",
+                                   "TST_HP_05",
+                                   "TST_HP_01"],
+                "energy_flow" => [[1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_04",
-                    "TST_HP_05",
-                    "TST_HP_02"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_04",
+                                  "TST_HP_05",
+                                  "TST_HP_02"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1],
+                                  [1]],
+            ),
+        ),
     )
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH2 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_BUS_TH1 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH2 s_control",
-        "TST_BUS_EL s_control",
-        "TST_BUS_TH1 s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH2 s_process",
-        "TST_BUS_EL s_process",
-        "TST_BUS_TH1 s_process",
-        "TST_HP_04 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_03 s_process",
-        "TST_HP_04 s_process",
-        "TST_HP_05 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_BUS_TH2 s_distribute",
-        "TST_BUS_EL s_distribute",
-        "TST_BUS_TH1 s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH2 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_BUS_TH1 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH2 s_control",
+                "TST_BUS_EL s_control",
+                "TST_BUS_TH1 s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH2 s_process",
+                "TST_BUS_EL s_process",
+                "TST_BUS_TH1 s_process",
+                "TST_HP_04 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_03 s_process",
+                "TST_HP_04 s_process",
+                "TST_HP_05 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_BUS_TH2 s_distribute",
+                "TST_BUS_EL s_distribute",
+                "TST_BUS_TH1 s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -1306,7 +1100,7 @@ function test_ooo_parallels_in_chain()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 70,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -1314,7 +1108,7 @@ function test_ooo_parallels_in_chain()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 90,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_03" => Dict{String,Any}(
             "type" => "Demand",
@@ -1322,138 +1116,107 @@ function test_ooo_parallels_in_chain()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_GRI_H2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_h2",
-            "input_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
         ),
         "TST_GRI_O2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_o2",
-            "input_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_00"
-            ],
+            "output_refs" => ["TST_BUS_00"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_GRI_00" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_01_ELY_01"],
+            "is_source" => true,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_HP_01"],
+            "is_source" => true,
         ),
         "TST_SRC_1b" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_01b"
-            ],
+            "output_refs" => ["TST_HP_01b"],
             "is_source" => true,
-            "constant_power" => 400
+            "constant_power" => 400,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_HP_02"],
+            "is_source" => true,
         ),
         "TST_GRI_03" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_03"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_HP_03"],
+            "is_source" => true,
         ),
         "TST_GRI_04" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_HP_04"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_HP_01b"
-            ],
+            "output_refs" => ["TST_HP_01b"],
             "power_th" => 1200,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_01b" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "power_th" => 9000,
             "min_power_fraction" => 0.0,
-            "input_temperature" => 60
+            "input_temperature" => 60,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_BUS_01"
-            ],
+            "output_refs" => ["TST_BUS_01"],
             "power_th" => 9000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "power_th" => 9000,
             "min_power_fraction" => 0.0,
-            "input_temperature" => 70
+            "input_temperature" => 70,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_03"
-            ],
+            "output_refs" => ["TST_DEM_03"],
             "power_th" => 9000,
             "min_power_fraction" => 0.0,
-            "input_temperature" => 70
+            "input_temperature" => 70,
         ),
-
         "TST_01_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_BUS_00",
-                "TST_GRI_H2",
-                "TST_GRI_O2"
-            ],
+            "output_refs" => ["TST_BUS_00",
+                              "TST_GRI_H2",
+                              "TST_GRI_O2"],
             "m_heat_ht_out" => "m_h_w_lt1",
             "output_temperature" => 45,
             "power_el" => 40000,
@@ -1461,125 +1224,111 @@ function test_ooo_parallels_in_chain()
             "nr_switchable_units" => 4,
             "dispatch_strategy" => "equal_with_mpf",
             "min_power_fraction_total" => 0.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_00" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_ELY_01",
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 1]
-                ]
-            )
+                "input_order" => ["TST_01_ELY_01",
+                                  "TST_SRC_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
+            ),
         ),
         "TST_BUS_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_01b",
-                    "TST_HP_02"
-                ],
-                "output_order" => [
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1],
-                    [1, 1, 1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_01b",
+                                  "TST_HP_02"],
+                "output_order" => ["TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_DEM_01"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 1, 1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_03 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_00 s_reset",
-        "TST_BUS_01 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_01_ELY_01 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_01b s_reset",
-        "TST_GRI_00 s_reset",
-        "TST_GRI_03 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_SRC_1b s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_04 s_reset",
-        "TST_GRI_O2 s_reset",
-        "TST_GRI_H2 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_03 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_00 s_control",
-        "TST_BUS_01 s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_03 s_control",
-        "TST_01_ELY_01 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_01b s_control",
-        "TST_GRI_00 s_control",
-        "TST_GRI_03 s_control",
-        "TST_GRI_02 s_control",
-        "TST_SRC_01 s_control",
-        "TST_SRC_1b s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_04 s_control",
-        "TST_GRI_O2 s_control",
-        "TST_GRI_H2 s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_03 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_00 s_process",
-        "TST_BUS_01 s_process",
-        "TST_01_ELY_01 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_01b s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_01b s_potential",
-        "TST_HP_02 s_potential",
-        "TST_01_ELY_01 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_01b s_process",
-        "TST_HP_02 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_04 s_process",
-        "TST_GRI_00 s_process",
-        "TST_GRI_03 s_process",
-        "TST_GRI_02 s_process",
-        "TST_SRC_01 s_process",
-        "TST_SRC_1b s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_04 s_process",
-        "TST_GRI_O2 s_process",
-        "TST_GRI_H2 s_process",
-        "TST_BUS_00 s_distribute",
-        "TST_BUS_01 s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_03 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_00 s_reset",
+                "TST_BUS_01 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_01_ELY_01 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_01b s_reset",
+                "TST_GRI_00 s_reset",
+                "TST_GRI_03 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_SRC_1b s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_04 s_reset",
+                "TST_GRI_O2 s_reset",
+                "TST_GRI_H2 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_03 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_00 s_control",
+                "TST_BUS_01 s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_03 s_control",
+                "TST_01_ELY_01 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_01b s_control",
+                "TST_GRI_00 s_control",
+                "TST_GRI_03 s_control",
+                "TST_GRI_02 s_control",
+                "TST_SRC_01 s_control",
+                "TST_SRC_1b s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_04 s_control",
+                "TST_GRI_O2 s_control",
+                "TST_GRI_H2 s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_03 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_00 s_process",
+                "TST_BUS_01 s_process",
+                "TST_01_ELY_01 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_01b s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_01b s_potential",
+                "TST_HP_02 s_potential",
+                "TST_01_ELY_01 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_01b s_process",
+                "TST_HP_02 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_04 s_process",
+                "TST_GRI_00 s_process",
+                "TST_GRI_03 s_process",
+                "TST_GRI_02 s_process",
+                "TST_SRC_01 s_process",
+                "TST_SRC_1b s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_04 s_process",
+                "TST_GRI_O2 s_process",
+                "TST_GRI_H2 s_process",
+                "TST_BUS_00 s_distribute",
+                "TST_BUS_01 s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -1597,254 +1346,208 @@ function test_ooo_parallels_in_a_row()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_BUS_TH1"
-            ],
+            "output_refs" => ["TST_BUS_TH1"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 500,
             "output_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 500,
             "output_temperature" => 40,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 500,
             "output_temperature" => 35,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 600,
             "output_temperature" => 45,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_06"
-            ],
+            "output_refs" => ["TST_HP_06"],
             "power_th" => 600,
             "output_temperature" => 65,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_06" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH3"
-            ],
+            "output_refs" => ["TST_BUS_TH3"],
             "power_th" => 600,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_07" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_08"
-            ],
+            "output_refs" => ["TST_HP_08"],
             "power_th" => 600,
             "output_temperature" => 75,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_08" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH3"
-            ],
+            "output_refs" => ["TST_BUS_TH3"],
             "power_th" => 600,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05",
-                    "TST_HP_06",
-                    "TST_HP_07",
-                    "TST_HP_08",
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05",
+                                   "TST_HP_06",
+                                   "TST_HP_07",
+                                   "TST_HP_08"],
+                "energy_flow" => [[1, 1, 1, 1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH1" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_SRC_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_03"
-                ],
-                "energy_flow" => [
-                    [1, 1]
-                ]
-            )
+                "input_order" => ["TST_SRC_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_03"],
+                "energy_flow" => [[1, 1]],
+            ),
         ),
         "TST_BUS_TH2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_HP_04"
-                ],
-                "output_order" => [
-                    "TST_HP_05",
-                    "TST_HP_07"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 1]
-                ]
-            )
+                "input_order" => ["TST_HP_02",
+                                  "TST_HP_04"],
+                "output_order" => ["TST_HP_05",
+                                   "TST_HP_07"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
+            ),
         ),
         "TST_BUS_TH3" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_06",
-                    "TST_HP_08"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_06",
+                                  "TST_HP_08"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH2 s_reset",
-        "TST_BUS_TH3 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_BUS_TH1 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_06 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_08 s_reset",
-        "TST_HP_07 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH2 s_control",
-        "TST_BUS_TH3 s_control",
-        "TST_BUS_EL s_control",
-        "TST_BUS_TH1 s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_06 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_08 s_control",
-        "TST_HP_07 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH2 s_process",
-        "TST_BUS_TH3 s_process",
-        "TST_BUS_EL s_process",
-        "TST_BUS_TH1 s_process",
-        "TST_HP_06 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_06 s_potential",
-        "TST_HP_08 s_potential",
-        "TST_HP_07 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_04 s_process",
-        "TST_HP_05 s_process",
-        "TST_HP_06 s_process",
-        "TST_HP_07 s_process",
-        "TST_HP_08 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_BUS_TH2 s_distribute",
-        "TST_BUS_TH3 s_distribute",
-        "TST_BUS_EL s_distribute",
-        "TST_BUS_TH1 s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH2 s_reset",
+                "TST_BUS_TH3 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_BUS_TH1 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_06 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_08 s_reset",
+                "TST_HP_07 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH2 s_control",
+                "TST_BUS_TH3 s_control",
+                "TST_BUS_EL s_control",
+                "TST_BUS_TH1 s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_06 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_08 s_control",
+                "TST_HP_07 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH2 s_process",
+                "TST_BUS_TH3 s_process",
+                "TST_BUS_EL s_process",
+                "TST_BUS_TH1 s_process",
+                "TST_HP_06 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_06 s_potential",
+                "TST_HP_08 s_potential",
+                "TST_HP_07 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_04 s_process",
+                "TST_HP_05 s_process",
+                "TST_HP_06 s_process",
+                "TST_HP_07 s_process",
+                "TST_HP_08 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_BUS_TH2 s_distribute",
+                "TST_BUS_TH3 s_distribute",
+                "TST_BUS_EL s_distribute",
+                "TST_BUS_TH1 s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -1853,7 +1556,6 @@ function test_ooo_parallels_in_a_row()
     end
     @test pwc_ooo_astr(expected, ooo) == ""
 end
-
 
 function test_ooo_connected_middle_busses()
     components_config = Dict{String,Any}(
@@ -1863,7 +1565,7 @@ function test_ooo_connected_middle_busses()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -1871,7 +1573,7 @@ function test_ooo_connected_middle_busses()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 95,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_DEM_03" => Dict{String,Any}(
             "type" => "Demand",
@@ -1879,314 +1581,264 @@ function test_ooo_connected_middle_busses()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "constant_temperature" => 115,
-            "scale" => 400
+            "scale" => 400,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_02" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_07"
-            ],
+            "output_refs" => ["TST_HP_07"],
             "max_power_profile_file_path" => "./profiles/tests/demand_electricity.prf",
             "constant_temperature" => 5,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_GRI_EL" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 1200,
             "output_temperature" => 10,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH_01"
-            ],
+            "output_refs" => ["TST_BUS_TH_01"],
             "power_th" => 1200,
             "output_temperature" => 25,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_04"
-            ],
+            "output_refs" => ["TST_HP_04"],
             "power_th" => 1200,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_04" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_01"
-            ],
+            "output_refs" => ["TST_DEM_01"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_05" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_06"
-            ],
+            "output_refs" => ["TST_HP_06"],
             "power_th" => 1200,
             "output_temperature" => 45,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_06" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH_02"
-            ],
+            "output_refs" => ["TST_BUS_TH_02"],
             "power_th" => 1200,
             "output_temperature" => 55,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_07" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_08"
-            ],
+            "output_refs" => ["TST_HP_08"],
             "power_th" => 1200,
             "output_temperature" => 35,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_08" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH_02"
-            ],
+            "output_refs" => ["TST_BUS_TH_02"],
             "power_th" => 1200,
             "output_temperature" => 60,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_09" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_10"
-            ],
+            "output_refs" => ["TST_HP_10"],
             "power_th" => 1200,
             "output_temperature" => 80,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_10" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_11" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_12"
-            ],
+            "output_refs" => ["TST_HP_12"],
             "power_th" => 1200,
             "output_temperature" => 90,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_12" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_03"
-            ],
+            "output_refs" => ["TST_DEM_03"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_GRI_EL"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_HP_04",
-                    "TST_HP_05",
-                    "TST_HP_06",
-                    "TST_HP_07",
-                    "TST_HP_08",
-                    "TST_HP_09",
-                    "TST_HP_10",
-                    "TST_HP_11",
-                    "TST_HP_12"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_GRI_EL"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_HP_04",
+                                   "TST_HP_05",
+                                   "TST_HP_06",
+                                   "TST_HP_07",
+                                   "TST_HP_08",
+                                   "TST_HP_09",
+                                   "TST_HP_10",
+                                   "TST_HP_11",
+                                   "TST_HP_12"],
+                "energy_flow" => [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH_01" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02"
-                ],
-                "output_order" => [
-                    "TST_HP_03",
-                    "TST_HP_05"
-                ],
-                "energy_flow" => [
-                    [1, 1]
-                ]
-            )
+                "input_order" => ["TST_HP_02"],
+                "output_order" => ["TST_HP_03",
+                                   "TST_HP_05"],
+                "energy_flow" => [[1, 1]],
+            ),
         ),
         "TST_BUS_TH_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_06",
-                    "TST_HP_08"
-                ],
-                "output_order" => [
-                    "TST_HP_09",
-                    "TST_HP_11"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_06",
+                                  "TST_HP_08"],
+                "output_order" => ["TST_HP_09",
+                                   "TST_HP_11"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_03 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH_01 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_BUS_TH_02 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_09 s_reset",
-        "TST_HP_12 s_reset",
-        "TST_HP_06 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_HP_05 s_reset",
-        "TST_HP_10 s_reset",
-        "TST_HP_11 s_reset",
-        "TST_HP_04 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_08 s_reset",
-        "TST_HP_07 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_SRC_02 s_reset",
-        "TST_GRI_EL s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_03 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH_01 s_control",
-        "TST_BUS_EL s_control",
-        "TST_BUS_TH_02 s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_09 s_control",
-        "TST_HP_12 s_control",
-        "TST_HP_06 s_control",
-        "TST_HP_03 s_control",
-        "TST_HP_05 s_control",
-        "TST_HP_10 s_control",
-        "TST_HP_11 s_control",
-        "TST_HP_04 s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_08 s_control",
-        "TST_HP_07 s_control",
-        "TST_SRC_01 s_control",
-        "TST_SRC_02 s_control",
-        "TST_GRI_EL s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_03 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH_01 s_process",
-        "TST_BUS_EL s_process",
-        "TST_BUS_TH_02 s_process",
-        "TST_HP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_04 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_10 s_potential",
-        "TST_HP_09 s_potential",
-        "TST_HP_12 s_potential",
-        "TST_HP_11 s_potential",
-        "TST_HP_07 s_potential",
-        "TST_HP_08 s_potential",
-        "TST_HP_06 s_potential",
-        "TST_HP_05 s_potential",
-        "TST_HP_02 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_04 s_process",
-        "TST_HP_05 s_process",
-        "TST_HP_06 s_process",
-        "TST_HP_08 s_process",
-        "TST_HP_07 s_process",
-        "TST_HP_09 s_process",
-        "TST_HP_10 s_process",
-        "TST_HP_11 s_process",
-        "TST_HP_12 s_process",
-        "TST_SRC_01 s_process",
-        "TST_SRC_02 s_process",
-        "TST_GRI_EL s_process",
-        "TST_BUS_TH_01 s_distribute",
-        "TST_BUS_EL s_distribute",
-        "TST_BUS_TH_02 s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_03 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH_01 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_BUS_TH_02 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_09 s_reset",
+                "TST_HP_12 s_reset",
+                "TST_HP_06 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_HP_05 s_reset",
+                "TST_HP_10 s_reset",
+                "TST_HP_11 s_reset",
+                "TST_HP_04 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_08 s_reset",
+                "TST_HP_07 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_SRC_02 s_reset",
+                "TST_GRI_EL s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_03 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH_01 s_control",
+                "TST_BUS_EL s_control",
+                "TST_BUS_TH_02 s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_09 s_control",
+                "TST_HP_12 s_control",
+                "TST_HP_06 s_control",
+                "TST_HP_03 s_control",
+                "TST_HP_05 s_control",
+                "TST_HP_10 s_control",
+                "TST_HP_11 s_control",
+                "TST_HP_04 s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_08 s_control",
+                "TST_HP_07 s_control",
+                "TST_SRC_01 s_control",
+                "TST_SRC_02 s_control",
+                "TST_GRI_EL s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_03 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH_01 s_process",
+                "TST_BUS_EL s_process",
+                "TST_BUS_TH_02 s_process",
+                "TST_HP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_04 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_10 s_potential",
+                "TST_HP_09 s_potential",
+                "TST_HP_12 s_potential",
+                "TST_HP_11 s_potential",
+                "TST_HP_07 s_potential",
+                "TST_HP_08 s_potential",
+                "TST_HP_06 s_potential",
+                "TST_HP_05 s_potential",
+                "TST_HP_02 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_04 s_process",
+                "TST_HP_05 s_process",
+                "TST_HP_06 s_process",
+                "TST_HP_08 s_process",
+                "TST_HP_07 s_process",
+                "TST_HP_09 s_process",
+                "TST_HP_10 s_process",
+                "TST_HP_11 s_process",
+                "TST_HP_12 s_process",
+                "TST_SRC_01 s_process",
+                "TST_SRC_02 s_process",
+                "TST_GRI_EL s_process",
+                "TST_BUS_TH_01 s_distribute",
+                "TST_BUS_EL s_distribute",
+                "TST_BUS_TH_02 s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -2196,7 +1848,6 @@ function test_ooo_connected_middle_busses()
     @test pwc_ooo_astr(expected, ooo) == ""
 end
 
-
 function test_ooo_connected_middle_transformer()
     components_config = Dict{String,Any}(
         "TST_DEM_01" => Dict{String,Any}(
@@ -2205,7 +1856,7 @@ function test_ooo_connected_middle_transformer()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -2213,68 +1864,54 @@ function test_ooo_connected_middle_transformer()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 90,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_GRI_O2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_o2",
-            "input_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_GRI_NG" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 1200,
             "output_temperature" => 50,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 9000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_01_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_HP_01",
-                "TST_BUS_H2",
-                "TST_GRI_O2"
-            ],
+            "output_refs" => ["TST_HP_01",
+                              "TST_BUS_H2",
+                              "TST_GRI_O2"],
             "m_heat_ht_out" => "m_h_w_lt1",
             "output_temperature" => 45,
             "power_el" => 40000,
@@ -2282,139 +1919,115 @@ function test_ooo_connected_middle_transformer()
             "nr_switchable_units" => 4,
             "dispatch_strategy" => "equal_with_mpf",
             "min_power_fraction_total" => 0.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "ESS_FBH2_01" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_DEM_02"
-            ],
+            "output_refs" => ["TST_DEM_02"],
             "min_power_fraction" => 0,
-            "power_th" => 1500
+            "power_th" => 1500,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_01_ELY_01",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_01_ELY_01",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 1, 1, 1],
+                                  [1, 1, 1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_CHP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
+                "input_order" => ["TST_HP_02",
+                                  "TST_CHP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
         ),
         "TST_BUS_H2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_c_g_h2",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_ELY_01"
-                ],
-                "output_order" => [
-                    "ESS_FBH2_01"
-                ],
-                "energy_flow" => [
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_01_ELY_01"],
+                "output_order" => ["ESS_FBH2_01"],
+                "energy_flow" => [[1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_H2 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_01_ELY_01 s_reset",
-        "TST_HP_02 s_reset",
-        "ESS_FBH2_01 s_reset",
-        "TST_GRI_NG s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_GRI_O2 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_H2 s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_CHP_01 s_control",
-        "TST_01_ELY_01 s_control",
-        "TST_HP_02 s_control",
-        "ESS_FBH2_01 s_control",
-        "TST_GRI_NG s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_GRI_O2 s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_H2 s_process",
-        "TST_BUS_EL s_process",
-        "TST_CHP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_01 s_potential",
-        "ESS_FBH2_01 s_potential",
-        "TST_01_ELY_01 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_CHP_01 s_process",
-        "ESS_FBH2_01 s_process",
-        "TST_GRI_NG s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_GRI_O2 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_H2 s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_H2 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_01_ELY_01 s_reset",
+                "TST_HP_02 s_reset",
+                "ESS_FBH2_01 s_reset",
+                "TST_GRI_NG s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_GRI_O2 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_H2 s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_CHP_01 s_control",
+                "TST_01_ELY_01 s_control",
+                "TST_HP_02 s_control",
+                "ESS_FBH2_01 s_control",
+                "TST_GRI_NG s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_GRI_O2 s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_H2 s_process",
+                "TST_BUS_EL s_process",
+                "TST_CHP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_01 s_potential",
+                "ESS_FBH2_01 s_potential",
+                "TST_01_ELY_01 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_CHP_01 s_process",
+                "ESS_FBH2_01 s_process",
+                "TST_GRI_NG s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_GRI_O2 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_H2 s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -2432,7 +2045,7 @@ function test_ooo_connected_middle_transformer_variant()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -2440,85 +2053,69 @@ function test_ooo_connected_middle_transformer_variant()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 90,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_GRI_O2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_o2",
-            "input_refs" => [
-                "TST_01_ELY_01"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_SRC_01" => Dict{String,Any}(
-        "type" => "BoundedSupply",
-        "medium" => "m_h_w_lt1",
-        "output_refs" => ["TST_HP_03"],
-        "constant_temperature" => 20,
-        "constant_power" => 100000
+            "type" => "BoundedSupply",
+            "medium" => "m_h_w_lt1",
+            "output_refs" => ["TST_HP_03"],
+            "constant_temperature" => 20,
+            "constant_power" => 100000,
         ),
         "TST_GRI_NG" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 1200,
             "output_temperature" => 50,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 9000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "power_th" => 9000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_01_ELY_01" => Dict{String,Any}(
             "type" => "Electrolyser",
-            "output_refs" => [
-                "TST_HP_01",
-                "TST_BUS_H2",
-                "TST_GRI_O2"
-            ],
+            "output_refs" => ["TST_HP_01",
+                              "TST_BUS_H2",
+                              "TST_GRI_O2"],
             "m_heat_ht_out" => "m_h_w_lt1",
             "output_temperature" => 45,
             "power_el" => 40000,
@@ -2526,170 +2123,140 @@ function test_ooo_connected_middle_transformer_variant()
             "nr_switchable_units" => 4,
             "dispatch_strategy" => "equal_with_mpf",
             "min_power_fraction_total" => 0.0,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "ESS_FBH2_01" => Dict{String,Any}(
             "type" => "FuelBoiler",
             "m_fuel_in" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_BUS_TH2"
-            ],
+            "output_refs" => ["TST_BUS_TH2"],
             "min_power_fraction" => 0,
-            "power_th" => 1500
+            "power_th" => 1500,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_g_h2",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "control_parameters" => Dict{String,Any}(
-                "load_storages m_h_w_ht1" => false
+                "load_storages m_h_w_ht1" => false,
             ),
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_HP_03",
-                    "TST_01_ELY_01",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1, 1, 1],
-                    [1, 1, 1, 1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_HP_03",
+                                   "TST_01_ELY_01",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 1, 1, 1, 1],
+                                  [1, 1, 1, 1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_CHP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
+                "input_order" => ["TST_HP_02",
+                                  "TST_CHP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
         ),
         "TST_BUS_TH2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "ESS_FBH2_01",
-                    "TST_HP_03"
-                ],
-                "output_order" => [
-                    "TST_DEM_02"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
+                "input_order" => ["ESS_FBH2_01",
+                                  "TST_HP_03"],
+                "output_order" => ["TST_DEM_02"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
         ),
         "TST_BUS_H2" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_c_g_h2",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_01_ELY_01"
-                ],
-                "output_order" => [
-                    "ESS_FBH2_01"
-                ],
-                "energy_flow" => [
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_01_ELY_01"],
+                "output_order" => ["ESS_FBH2_01"],
+                "energy_flow" => [[1]],
+            ),
+        ),
     )
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH2 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_H2 s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_01_ELY_01 s_reset",
-        "TST_HP_02 s_reset",
-        "ESS_FBH2_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_NG s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_GRI_O2 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH2 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_H2 s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_03 s_control",
-        "TST_CHP_01 s_control",
-        "TST_01_ELY_01 s_control",
-        "TST_HP_02 s_control",
-        "ESS_FBH2_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_NG s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_GRI_O2 s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH2 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_H2 s_process",
-        "TST_BUS_EL s_process",
-        "TST_CHP_01 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_HP_01 s_potential",
-        "TST_HP_03 s_potential",
-        "ESS_FBH2_01 s_potential",
-        "TST_01_ELY_01 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_CHP_01 s_process",
-        "ESS_FBH2_01 s_process",
-        "TST_HP_03 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_NG s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_GRI_O2 s_process",
-        "TST_BUS_TH2 s_distribute",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_H2 s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH2 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_H2 s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_01_ELY_01 s_reset",
+                "TST_HP_02 s_reset",
+                "ESS_FBH2_01 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_NG s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_GRI_O2 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH2 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_H2 s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_03 s_control",
+                "TST_CHP_01 s_control",
+                "TST_01_ELY_01 s_control",
+                "TST_HP_02 s_control",
+                "ESS_FBH2_01 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_NG s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_GRI_O2 s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH2 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_H2 s_process",
+                "TST_BUS_EL s_process",
+                "TST_CHP_01 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_HP_01 s_potential",
+                "TST_HP_03 s_potential",
+                "ESS_FBH2_01 s_potential",
+                "TST_01_ELY_01 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_CHP_01 s_process",
+                "ESS_FBH2_01 s_process",
+                "TST_HP_03 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_NG s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_GRI_O2 s_process",
+                "TST_BUS_TH2 s_distribute",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_H2 s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -2707,139 +2274,113 @@ function test_ooo_circle_grid_input_denied()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_GRI_natgas" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 0],
-                    [1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 0],
+                                  [1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_01",
-                    "TST_CHP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_01",
+                                  "TST_CHP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_natgas s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_CHP_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_natgas s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_CHP_01 s_potential",
-        "TST_HP_01 s_process",
-        "TST_CHP_01 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_natgas s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_natgas s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_CHP_01 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_natgas s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_CHP_01 s_potential",
+                "TST_HP_01 s_process",
+                "TST_CHP_01 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_natgas s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -2857,139 +2398,113 @@ function test_ooo_circle_grid_input_allowed()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_GRI_natgas" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 1],
+                                  [1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_01",
-                    "TST_CHP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_01",
+                                  "TST_CHP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_natgas s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_CHP_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_natgas s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_CHP_01 s_potential",
-        "TST_HP_01 s_process",
-        "TST_CHP_01 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_natgas s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_natgas s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_CHP_01 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_natgas s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_CHP_01 s_potential",
+                "TST_HP_01 s_process",
+                "TST_CHP_01 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_natgas s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -2999,8 +2514,6 @@ function test_ooo_circle_grid_input_allowed()
     @test pwc_ooo_astr(expected, ooo) == ""
 end
 
-
-
 function test_ooo_circle_middle_transformer_input()
     components_config = Dict{String,Any}(
         "TST_DEM_01" => Dict{String,Any}(
@@ -3009,155 +2522,126 @@ function test_ooo_circle_middle_transformer_input()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_GRI_natgas" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02"
-            ],
+            "output_refs" => ["TST_HP_02"],
             "power_th" => 500,
             "output_temperature" => 65,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
-
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 1, 0],
-                    [1, 1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_HP_02",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 1, 0],
+                                  [1, 1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_02",
-                    "TST_CHP_01"
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_02",
+                                  "TST_CHP_01"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_02 s_reset",
-        "TST_HP_01 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_natgas s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_02 s_control",
-        "TST_HP_01 s_control",
-        "TST_CHP_01 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_natgas s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_CHP_01 s_potential",
-        "TST_HP_02 s_process",
-        "TST_HP_01 s_process",
-        "TST_CHP_01 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_natgas s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_02 s_reset",
+                "TST_HP_01 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_natgas s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_02 s_control",
+                "TST_HP_01 s_control",
+                "TST_CHP_01 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_natgas s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_CHP_01 s_potential",
+                "TST_HP_02 s_process",
+                "TST_HP_01 s_process",
+                "TST_CHP_01 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_natgas s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -3175,170 +2659,139 @@ function test_ooo_circle_variant()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 1000
+            "scale" => 1000,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 5
+            "constant_temperature" => 5,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_GRI_natgas_1" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_GRI_natgas_2" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_02"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_02"],
+            "is_source" => true,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_lt1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 500,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_CHP_02" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_BUS_TH",
+                              "TST_BUS_EL"],
             "power_el" => 120000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_CHP_02",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_01",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [1, 1],
-                    [1, 0],
-                    [1, 0]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_CHP_02",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_01",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[1, 1],
+                                  [1, 0],
+                                  [1, 0]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_01",
-                    "TST_CHP_01",
-                    "TST_CHP_02"
-
-                ],
-                "output_order" => [
-                    "TST_DEM_01"
-                ],
-                "energy_flow" => [
-                    [1],
-                    [1],
-                    [1]
-                ]
-            )
-        )
+                "input_order" => ["TST_HP_01",
+                                  "TST_CHP_01",
+                                  "TST_CHP_02"],
+                "output_order" => ["TST_DEM_01"],
+                "energy_flow" => [[1],
+                                  [1],
+                                  [1]],
+            ),
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_CHP_02 s_reset",
-        "TST_GRI_natgas_2 s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_natgas_1 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_CHP_01 s_control",
-        "TST_CHP_02 s_control",
-        "TST_GRI_natgas_2 s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_natgas_1 s_control",
-        "TST_GRI_02 s_control",
-        "TST_DEM_01 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_CHP_02 s_potential",
-        "TST_CHP_01 s_potential",
-        "TST_HP_01 s_process",
-        "TST_CHP_01 s_process",
-        "TST_CHP_02 s_process",
-        "TST_GRI_natgas_2 s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_natgas_1 s_process",
-        "TST_GRI_02 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_CHP_02 s_reset",
+                "TST_GRI_natgas_2 s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_natgas_1 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_CHP_01 s_control",
+                "TST_CHP_02 s_control",
+                "TST_GRI_natgas_2 s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_natgas_1 s_control",
+                "TST_GRI_02 s_control",
+                "TST_DEM_01 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_CHP_02 s_potential",
+                "TST_CHP_01 s_potential",
+                "TST_HP_01 s_process",
+                "TST_CHP_01 s_process",
+                "TST_CHP_02 s_process",
+                "TST_GRI_natgas_2 s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_natgas_1 s_process",
+                "TST_GRI_02 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []
@@ -3356,7 +2809,7 @@ function test_ooo_circle_middle_transformer_interconnections()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 85,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_DEM_02" => Dict{String,Any}(
             "type" => "Demand",
@@ -3364,191 +2817,159 @@ function test_ooo_circle_middle_transformer_interconnections()
             "output_refs" => [],
             "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
             "constant_temperature" => 50,
-            "scale" => 500
+            "scale" => 500,
         ),
         "TST_SRC_01" => Dict{String,Any}(
             "type" => "BoundedSupply",
             "medium" => "m_h_w_lt1",
-            "output_refs" => [
-                "TST_HP_01"
-            ],
+            "output_refs" => ["TST_HP_01"],
             "constant_power" => 500000,
-            "constant_temperature" => 20
+            "constant_temperature" => 20,
         ),
         "TST_GRI_natgas" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_c_natgas",
-            "output_refs" => [
-                "TST_CHP_01"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_CHP_01"],
+            "is_source" => true,
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "output_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => true
+            "output_refs" => ["TST_BUS_EL"],
+            "is_source" => true,
         ),
         "TST_GRI_02" => Dict{String,Any}(
             "type" => "GridConnection",
             "medium" => "m_e_ac_230v",
-            "input_refs" => [
-                "TST_BUS_EL"
-            ],
-            "is_source" => false
+            "input_refs" => ["TST_BUS_EL"],
+            "is_source" => false,
         ),
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 1200,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_02" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "power_th" => 9000,
             "input_temperature" => 30,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_HP_03" => Dict{String,Any}(
             "type" => "HeatPump",
             "m_heat_in" => "m_h_w_ht1",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_DEM_01"
-            ],
+            "output_refs" => ["TST_DEM_01"],
             "power_th" => 9000,
             "input_temperature" => 50,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_CHP_01" => Dict{String,Any}(
             "type" => "CHPP",
             "m_fuel_in" => "m_c_natgas",
             "m_heat_out" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_HP_02",
-                "TST_BUS_EL"
-            ],
+            "output_refs" => ["TST_HP_02",
+                              "TST_BUS_EL"],
             "power_el" => 250000,
-            "min_power_fraction" => 0.0
+            "min_power_fraction" => 0.0,
         ),
         "TST_BUS_EL" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_e_ac_230v",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_CHP_01",
-                    "TST_GRI_01"
-                ],
-                "output_order" => [
-                    "TST_HP_02",
-                    "TST_HP_01",
-                    "TST_HP_03",
-                    "TST_GRI_02"
-                ],
-                "energy_flow" => [
-                    [0, 1, 1, 0],
-                    [1, 1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_CHP_01",
+                                  "TST_GRI_01"],
+                "output_order" => ["TST_HP_02",
+                                   "TST_HP_01",
+                                   "TST_HP_03",
+                                   "TST_GRI_02"],
+                "energy_flow" => [[0, 1, 1, 0],
+                                  [1, 1, 1, 1]],
+            ),
         ),
         "TST_BUS_TH" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
-                "input_order" => [
-                    "TST_HP_01",
-                    "TST_HP_02",
-                    "TST_BFT_TH_01"
-                ],
-                "output_order" => [
-                    "TST_HP_03",
-                    "TST_DEM_02",
-                    "TST_BFT_TH_01"
-                ],
-                "energy_flow" => [
-                    [1, 1, 1],
-                    [1, 1, 1],
-                    [1, 1, 1]
-                ]
-            )
+                "input_order" => ["TST_HP_01",
+                                  "TST_HP_02",
+                                  "TST_BFT_TH_01"],
+                "output_order" => ["TST_HP_03",
+                                   "TST_DEM_02",
+                                   "TST_BFT_TH_01"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 1, 1],
+                                  [1, 1, 1]],
+            ),
         ),
         "TST_BFT_TH_01" => Dict{String,Any}(
             "type" => "BufferTank",
             "medium" => "m_h_w_ht1",
-            "output_refs" => [
-                "TST_BUS_TH"
-            ],
+            "output_refs" => ["TST_BUS_TH"],
             "capacity" => 150000,
             "load" => 70000,
             "high_temperature" => 50.0,
             "low_temperature" => 20.0,
-            "use_adaptive_temperature" => false
-        )
+            "use_adaptive_temperature" => false,
+        ),
     )
 
-    expected = [
-        "TST_DEM_01 s_reset",
-        "TST_DEM_02 s_reset",
-        "TST_BUS_TH s_reset",
-        "TST_BUS_EL s_reset",
-        "TST_HP_01 s_reset",
-        "TST_HP_03 s_reset",
-        "TST_CHP_01 s_reset",
-        "TST_HP_02 s_reset",
-        "TST_BFT_TH_01 s_reset",
-        "TST_GRI_natgas s_reset",
-        "TST_SRC_01 s_reset",
-        "TST_GRI_01 s_reset",
-        "TST_GRI_02 s_reset",
-        "TST_DEM_01 s_control",
-        "TST_DEM_02 s_control",
-        "TST_BUS_TH s_control",
-        "TST_BUS_EL s_control",
-        "TST_HP_01 s_control",
-        "TST_HP_03 s_control",
-        "TST_CHP_01 s_control",
-        "TST_HP_02 s_control",
-        "TST_BFT_TH_01 s_control",
-        "TST_GRI_natgas s_control",
-        "TST_SRC_01 s_control",
-        "TST_GRI_01 s_control",
-        "TST_GRI_02 s_control",
-        "TST_DEM_01 s_process",
-        "TST_DEM_02 s_process",
-        "TST_BUS_TH s_process",
-        "TST_BUS_EL s_process",
-        "TST_HP_01 s_potential",
-        "TST_HP_03 s_potential",
-        "TST_HP_02 s_potential",
-        "TST_CHP_01 s_process",
-        "TST_HP_03 s_process",
-        "TST_HP_01 s_process",
-        "TST_HP_02 s_process",
-        "TST_BFT_TH_01 s_process",
-        "TST_BFT_TH_01 s_load",
-        "TST_GRI_natgas s_process",
-        "TST_SRC_01 s_process",
-        "TST_GRI_01 s_process",
-        "TST_GRI_02 s_process",
-        "TST_BUS_TH s_distribute",
-        "TST_BUS_EL s_distribute"
-    ]
+    expected = ["TST_DEM_01 s_reset",
+                "TST_DEM_02 s_reset",
+                "TST_BUS_TH s_reset",
+                "TST_BUS_EL s_reset",
+                "TST_HP_01 s_reset",
+                "TST_HP_03 s_reset",
+                "TST_CHP_01 s_reset",
+                "TST_HP_02 s_reset",
+                "TST_BFT_TH_01 s_reset",
+                "TST_GRI_natgas s_reset",
+                "TST_SRC_01 s_reset",
+                "TST_GRI_01 s_reset",
+                "TST_GRI_02 s_reset",
+                "TST_DEM_01 s_control",
+                "TST_DEM_02 s_control",
+                "TST_BUS_TH s_control",
+                "TST_BUS_EL s_control",
+                "TST_HP_01 s_control",
+                "TST_HP_03 s_control",
+                "TST_CHP_01 s_control",
+                "TST_HP_02 s_control",
+                "TST_BFT_TH_01 s_control",
+                "TST_GRI_natgas s_control",
+                "TST_SRC_01 s_control",
+                "TST_GRI_01 s_control",
+                "TST_GRI_02 s_control",
+                "TST_DEM_01 s_process",
+                "TST_DEM_02 s_process",
+                "TST_BUS_TH s_process",
+                "TST_BUS_EL s_process",
+                "TST_HP_01 s_potential",
+                "TST_HP_03 s_potential",
+                "TST_HP_02 s_potential",
+                "TST_CHP_01 s_process",
+                "TST_HP_03 s_process",
+                "TST_HP_01 s_process",
+                "TST_HP_02 s_process",
+                "TST_BFT_TH_01 s_process",
+                "TST_BFT_TH_01 s_load",
+                "TST_GRI_natgas s_process",
+                "TST_SRC_01 s_process",
+                "TST_GRI_01 s_process",
+                "TST_GRI_02 s_process",
+                "TST_BUS_TH s_distribute",
+                "TST_BUS_EL s_distribute"]
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
-    
+
     components = Resie.load_components(components_config, simulation_parameters)
     steps = Resie.calculate_order_of_operations(components)
     ooo = []

--- a/test/order_of_operations/transformer_chains_utils.jl
+++ b/test/order_of_operations/transformer_chains_utils.jl
@@ -10,48 +10,48 @@ function test_distance_from_sink()
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => ["TST_BUS_02", "TST_BUS_03"]
-            )
+                "output_order" => ["TST_BUS_02", "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
-                "output_order" => ["TST_BUS_04", "TST_BUS_05"]
-            )
+                "output_order" => ["TST_BUS_04", "TST_BUS_05"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_02"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_02"],
-                "output_order" => ["TST_BUS_06"]
-            )
+                "output_order" => ["TST_BUS_06"],
+            ),
         ),
         "TST_BUS_06" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_05"],
                 "output_order" => [],
-            )
+            ),
         ),
     )
 
@@ -59,7 +59,7 @@ function test_distance_from_sink()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -83,48 +83,48 @@ function test_iteration_order()
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => ["TST_BUS_02", "TST_BUS_03"]
-            )
+                "output_order" => ["TST_BUS_02", "TST_BUS_03"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
-                "output_order" => ["TST_BUS_04", "TST_BUS_05"]
-            )
+                "output_order" => ["TST_BUS_04", "TST_BUS_05"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_02"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_02"],
-                "output_order" => ["TST_BUS_06"]
-            )
+                "output_order" => ["TST_BUS_06"],
+            ),
         ),
         "TST_BUS_06" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_06"],
                 "output_order" => [],
-            )
+            ),
         ),
     )
 
@@ -132,28 +132,24 @@ function test_iteration_order()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
 
-    chain = [
-        components["TST_BUS_01"],
-        components["TST_BUS_02"],
-        components["TST_BUS_03"],
-        components["TST_BUS_04"],
-        components["TST_BUS_05"],
-        components["TST_BUS_06"],
-    ]
-    expected = [
-        components["TST_BUS_03"],
-        components["TST_BUS_04"],
-        components["TST_BUS_06"],
-        components["TST_BUS_05"],
-        components["TST_BUS_02"],
-        components["TST_BUS_01"],
-    ]
-    calculated = Resie.iterate_chain(chain, EnergySystems.sf_bus, reverse=false)
+    chain = [components["TST_BUS_01"],
+             components["TST_BUS_02"],
+             components["TST_BUS_03"],
+             components["TST_BUS_04"],
+             components["TST_BUS_05"],
+             components["TST_BUS_06"]]
+    expected = [components["TST_BUS_03"],
+                components["TST_BUS_04"],
+                components["TST_BUS_06"],
+                components["TST_BUS_05"],
+                components["TST_BUS_02"],
+                components["TST_BUS_01"]]
+    calculated = Resie.iterate_chain(chain, EnergySystems.sf_bus; reverse=false)
     for i in 1:6
         @test "#$i: " * calculated[i].uac == "#$i: " * expected[i].uac
     end
@@ -170,40 +166,40 @@ function test_find_chains()
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
                 "input_order" => [],
-                "output_order" => ["TST_BUS_02"]
-            )
+                "output_order" => ["TST_BUS_02"],
+            ),
         ),
         "TST_BUS_02" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_lt1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_01"],
-                "output_order" => ["TST_HTP_01", "TST_DEM_01"]
-            )
+                "output_order" => ["TST_HTP_01", "TST_DEM_01"],
+            ),
         ),
         "TST_BUS_03" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
             "connections" => Dict{String,Any}(
                 "input_order" => ["TST_HTP_01"],
-                "output_order" => ["TST_BUS_04", "TST_BUS_05"]
-            )
+                "output_order" => ["TST_BUS_04", "TST_BUS_05"],
+            ),
         ),
         "TST_BUS_04" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_03"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_BUS_05" => Dict{String,Any}(
             "type" => "Bus",
             "medium" => "m_h_w_ht1",
-            "connections" => Dict{String, Any}(
+            "connections" => Dict{String,Any}(
                 "input_order" => ["TST_BUS_03"],
                 "output_order" => [],
-            )
+            ),
         ),
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -215,14 +211,14 @@ function test_find_chains()
             "type" => "HeatPump",
             "output_refs" => ["TST_BUS_03"],
             "power_th" => 12000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
         "TST_DEM_01" => Dict{String,Any}(
             "type" => "Demand",
             "medium" => "m_h_w_lt1",
             "energy_profile_file_path" => "./profiles/tests/demand_heating_energy.prf",
             "temperature_profile_file_path" => "./profiles/tests/demand_heating_temperature.prf",
-            "scale" => 1000
+            "scale" => 1000,
         ),
     )
 
@@ -230,25 +226,19 @@ function test_find_chains()
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
 
-    expected_1 = Set([
-        components["TST_BUS_01"],
-        components["TST_BUS_02"],
-    ])
-    expected_2 = Set([
-        components["TST_BUS_03"],
-        components["TST_BUS_04"],
-        components["TST_BUS_05"],
-    ])
+    expected_1 = Set([components["TST_BUS_01"],
+                      components["TST_BUS_02"]])
+    expected_2 = Set([components["TST_BUS_03"],
+                      components["TST_BUS_04"],
+                      components["TST_BUS_05"]])
 
-    chains = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_bus
-    )
+    chains = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                               EnergySystems.sf_bus)
 
     @test length(chains) == 2
     @test chains[1] == expected_1
@@ -257,223 +247,181 @@ end
 
 function test_find_indirect_chains()
     components_config = Dict{String,Any}(
-            "TST_DEM_01" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 70,
-                "scale" => 500
+        "TST_DEM_01" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 70,
+            "scale" => 500,
+        ),
+        "TST_DEM_02" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 90,
+            "scale" => 500,
+        ),
+        "TST_DEM_03" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 95,
+            "scale" => 500,
+        ),
+        "TST_GRI_H2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_h2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_GRI_O2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_o2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_SRC_01" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_h_w_lt1",
+            "output_refs" => ["TST_BUS_00"],
+            "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
+            "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
+            "scale" => 1000,
+        ),
+        "TST_GRI_00" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_01_ELY_01"],
+            "is_source" => true,
+        ),
+        "TST_GRI_01" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01"],
+            "is_source" => true,
+        ),
+        "TST_SRC_1b" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01b"],
+            "is_source" => true,
+            "constant_power" => 400,
+        ),
+        "TST_GRI_02" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_02"],
+            "is_source" => true,
+        ),
+        "TST_GRI_03" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_03"],
+            "is_source" => true,
+        ),
+        "TST_GRI_04" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_04"],
+            "is_source" => true,
+        ),
+        "TST_HP_01" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_HP_01b"],
+            "power_th" => 1200,
+            "output_temperature" => 60,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_01b" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_02" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_03" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_02"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_04" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_03"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_01_ELY_01" => Dict{String,Any}(
+            "type" => "Electrolyser",
+            "output_refs" => ["TST_BUS_00",
+                              "TST_GRI_H2",
+                              "TST_GRI_O2"],
+            "m_heat_ht_out" => "m_h_w_lt1",
+            "output_temperature" => 45,
+            "power_el" => 40000,
+            "heat_lt_is_usable" => false,
+            "nr_switchable_units" => 4,
+            "dispatch_strategy" => "equal_with_mpf",
+            "min_power_fraction_total" => 0.0,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_BUS_00" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_lt1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
+                "output_order" => ["TST_HP_02", "TST_HP_01"],
+                "energy_flow" => [[1, 1],
+                                  [1, 0]],
             ),
-            "TST_DEM_02" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 90,
-                "scale" => 500
+        ),
+        "TST_BUS_01" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_ht1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_HP_01b", "TST_HP_02"],
+                "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01"],
+                "energy_flow" => [[1, 1, 1],
+                                  [1, 1, 1]],
             ),
-            "TST_DEM_03" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 95,
-                "scale" => 500
-            ),
-            "TST_GRI_H2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_h2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_GRI_O2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_o2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_SRC_01" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_h_w_lt1",
-                "output_refs" => [
-                    "TST_BUS_00"
-                ],
-                "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
-                "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
-                "scale" => 1000
-            ),
-            "TST_GRI_00" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_01" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_SRC_1b" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "is_source" => true,
-                "constant_power" => 400
-            ),
-            "TST_GRI_02" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_02"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_03" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_03"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_04" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_04"
-                ],
-                "is_source" => true
-            ),
-    
-            "TST_HP_01" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "power_th" => 1200,
-                "output_temperature" => 60,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_01b" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_02" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_03" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_02"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_04" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_03"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-    
-            "TST_01_ELY_01" => Dict{String,Any}(
-                "type" => "Electrolyser",
-                "output_refs" => [
-                    "TST_BUS_00",
-                    "TST_GRI_H2",
-                    "TST_GRI_O2"
-                ],
-                "m_heat_ht_out" => "m_h_w_lt1",
-                "output_temperature" => 45,
-                "power_el" => 40000,
-                "heat_lt_is_usable" => false,
-                "nr_switchable_units" => 4,
-                "dispatch_strategy" => "equal_with_mpf",
-                "min_power_fraction_total" => 0.0,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_BUS_00" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_lt1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
-                    "output_order" => ["TST_HP_02", "TST_HP_01"],
-                    "energy_flow" => [[1, 1],
-                                      [1, 0]]
-                    )
-            ),
-            "TST_BUS_01" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_ht1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_HP_01b", "TST_HP_02"],
-                    "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01" ],
-                    "energy_flow" => [[1, 1, 1],
-                                      [1, 1, 1]]
-                )
-            )
+        ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
 
-    expected_bus1 = Set([
-        components["TST_BUS_00"],
-    ])
-    expected_bus2 = Set([
-        components["TST_BUS_01"],
-    ])
-    expected_transformer = Set([
-        components["TST_HP_01"],
-        components["TST_HP_01b"],
-        components["TST_HP_02"],
-        components["TST_HP_03"],
-        components["TST_HP_04"],
-        components["TST_01_ELY_01"],
-    ])
+    expected_bus1 = Set([components["TST_BUS_00"]])
+    expected_bus2 = Set([components["TST_BUS_01"]])
+    expected_transformer = Set([components["TST_HP_01"],
+                                components["TST_HP_01b"],
+                                components["TST_HP_02"],
+                                components["TST_HP_03"],
+                                components["TST_HP_04"],
+                                components["TST_01_ELY_01"]])
 
-    chains_bus = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_bus
-    )
+    chains_bus = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                   EnergySystems.sf_bus)
 
-    chains_transformer = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_transformer,
-        direct_connection_only=false
-    )
+    chains_transformer = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                           EnergySystems.sf_transformer;
+                                           direct_connection_only=false)
 
     @test length(chains_bus) == 2
     @test chains_bus[1] == expected_bus1
@@ -490,13 +438,20 @@ function test_find_indirect_chains()
     @test Resie.distance_to_sink(components["TST_01_ELY_01"], EnergySystems.sf_transformer, [], "") == 5
 
     # test function to determine if transformers are at interfaces, considers energy flow matrix of bus
-    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out], "output") == false
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in], "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out],
+                                                "output") == false
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in],
+                                                "input") == true
 end
 
 function test_find_indirect_chains_denied()
@@ -504,225 +459,181 @@ function test_find_indirect_chains_denied()
     # of the two busses denies the connection to and from HP1/HP1b to other transformers. 
     # Therefore, here two independent transformer chains are detected instead of one.
     components_config = Dict{String,Any}(
-            "TST_DEM_01" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 70,
-                "scale" => 500
+        "TST_DEM_01" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 70,
+            "scale" => 500,
+        ),
+        "TST_DEM_02" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 90,
+            "scale" => 500,
+        ),
+        "TST_DEM_03" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 95,
+            "scale" => 500,
+        ),
+        "TST_GRI_H2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_h2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_GRI_O2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_o2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_SRC_01" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_h_w_lt1",
+            "output_refs" => ["TST_BUS_00"],
+            "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
+            "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
+            "scale" => 1000,
+        ),
+        "TST_GRI_00" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_01_ELY_01"],
+            "is_source" => true,
+        ),
+        "TST_GRI_01" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01"],
+            "is_source" => true,
+        ),
+        "TST_SRC_1b" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01b"],
+            "is_source" => true,
+            "constant_power" => 400,
+        ),
+        "TST_GRI_02" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_02"],
+            "is_source" => true,
+        ),
+        "TST_GRI_03" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_03"],
+            "is_source" => true,
+        ),
+        "TST_GRI_04" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_04"],
+            "is_source" => true,
+        ),
+        "TST_HP_01" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_HP_01b"],
+            "power_th" => 1200,
+            "output_temperature" => 60,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_01b" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_02" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_03" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_02"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_04" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_03"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_01_ELY_01" => Dict{String,Any}(
+            "type" => "Electrolyser",
+            "output_refs" => ["TST_BUS_00",
+                              "TST_GRI_H2",
+                              "TST_GRI_O2"],
+            "m_heat_ht_out" => "m_h_w_lt1",
+            "output_temperature" => 45,
+            "power_el" => 40000,
+            "heat_lt_is_usable" => false,
+            "nr_switchable_units" => 4,
+            "dispatch_strategy" => "equal_with_mpf",
+            "min_power_fraction_total" => 0.0,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_BUS_00" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_lt1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
+                "output_order" => ["TST_HP_02", "TST_HP_01"],
+                "energy_flow" => [[1, 0],
+                                  [1, 1]],
             ),
-            "TST_DEM_02" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 90,
-                "scale" => 500
+        ),
+        "TST_BUS_01" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_ht1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_HP_01b", "TST_HP_02"],
+                "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01"],
+                "energy_flow" => [[0, 0, 1],
+                                  [1, 1, 1]],
             ),
-            "TST_DEM_03" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 95,
-                "scale" => 500
-            ),
-            "TST_GRI_H2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_h2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_GRI_O2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_o2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_SRC_01" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_h_w_lt1",
-                "output_refs" => [
-                    "TST_BUS_00"
-                ],
-                "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
-                "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
-                "scale" => 1000
-            ),
-            "TST_GRI_00" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_01" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_SRC_1b" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "is_source" => true,
-                "constant_power" => 400
-            ),
-            "TST_GRI_02" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_02"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_03" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_03"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_04" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_04"
-                ],
-                "is_source" => true
-            ),
-    
-            "TST_HP_01" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "power_th" => 1200,
-                "output_temperature" => 60,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_01b" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_02" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_03" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_02"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_04" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_03"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-    
-            "TST_01_ELY_01" => Dict{String,Any}(
-                "type" => "Electrolyser",
-                "output_refs" => [
-                    "TST_BUS_00",
-                    "TST_GRI_H2",
-                    "TST_GRI_O2"
-                ],
-                "m_heat_ht_out" => "m_h_w_lt1",
-                "output_temperature" => 45,
-                "power_el" => 40000,
-                "heat_lt_is_usable" => false,
-                "nr_switchable_units" => 4,
-                "dispatch_strategy" => "equal_with_mpf",
-                "min_power_fraction_total" => 0.0,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_BUS_00" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_lt1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
-                    "output_order" => ["TST_HP_02", "TST_HP_01"],
-                    "energy_flow" => [[1, 0],
-                                      [1, 1]]
-                    )
-            ),
-            "TST_BUS_01" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_ht1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_HP_01b", "TST_HP_02"],
-                    "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01" ],
-                    "energy_flow" => [[0, 0, 1],
-                                      [1, 1, 1]]
-                )
-            )
+        ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
 
-    expected_bus1 = Set([
-        components["TST_BUS_00"],
-    ])
-    expected_bus2 = Set([
-        components["TST_BUS_01"],
-    ])
-    expected_transformer1 = Set([
-        components["TST_HP_02"],
-        components["TST_HP_03"],
-        components["TST_HP_04"],
-        components["TST_01_ELY_01"],
-    ])
-    expected_transformer2 = Set([
-        components["TST_HP_01"],
-        components["TST_HP_01b"],
-    ])
+    expected_bus1 = Set([components["TST_BUS_00"]])
+    expected_bus2 = Set([components["TST_BUS_01"]])
+    expected_transformer1 = Set([components["TST_HP_02"],
+                                 components["TST_HP_03"],
+                                 components["TST_HP_04"],
+                                 components["TST_01_ELY_01"]])
+    expected_transformer2 = Set([components["TST_HP_01"],
+                                 components["TST_HP_01b"]])
 
-    chains_bus = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_bus
-    )
+    chains_bus = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                   EnergySystems.sf_bus)
 
-    chains_transformer = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_transformer,
-        direct_connection_only=false
-    )
+    chains_transformer = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                           EnergySystems.sf_transformer;
+                                           direct_connection_only=false)
 
     @test length(chains_bus) == 2
     @test chains_bus[1] == expected_bus1
@@ -740,14 +651,20 @@ function test_find_indirect_chains_denied()
     @test Resie.distance_to_sink(components["TST_01_ELY_01"], EnergySystems.sf_transformer, [], "") == 4
 
     # test function to determine if transformers are at interfaces, considers energy flow matrix of bus
-    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out], "output") == false
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out], "output") == false
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in], "input") == true
-
+    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out],
+                                                "output") == false
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out],
+                                                "output") == false
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in],
+                                                "input") == true
 end
 
 function test_find_indirect_chains_denied2()
@@ -756,226 +673,181 @@ function test_find_indirect_chains_denied2()
     # Therefore, here two independent transformer chains are detected instead of one. One chain
     # is only HP4.
     components_config = Dict{String,Any}(
-            "TST_DEM_01" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 70,
-                "scale" => 500
+        "TST_DEM_01" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 70,
+            "scale" => 500,
+        ),
+        "TST_DEM_02" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 90,
+            "scale" => 500,
+        ),
+        "TST_DEM_03" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
+            "constant_temperature" => 95,
+            "scale" => 500,
+        ),
+        "TST_GRI_H2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_h2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_GRI_O2" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_c_g_o2",
+            "input_refs" => ["TST_01_ELY_01"],
+            "is_source" => false,
+        ),
+        "TST_SRC_01" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_h_w_lt1",
+            "output_refs" => ["TST_BUS_00"],
+            "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
+            "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
+            "scale" => 1000,
+        ),
+        "TST_GRI_00" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_01_ELY_01"],
+            "is_source" => true,
+        ),
+        "TST_GRI_01" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01"],
+            "is_source" => true,
+        ),
+        "TST_SRC_1b" => Dict{String,Any}(
+            "type" => "BoundedSupply",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_01b"],
+            "is_source" => true,
+            "constant_power" => 400,
+        ),
+        "TST_GRI_02" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_02"],
+            "is_source" => true,
+        ),
+        "TST_GRI_03" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_03"],
+            "is_source" => true,
+        ),
+        "TST_GRI_04" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_e_ac_230v",
+            "output_refs" => ["TST_HP_04"],
+            "is_source" => true,
+        ),
+        "TST_HP_01" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_HP_01b"],
+            "power_th" => 1200,
+            "output_temperature" => 60,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_01b" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_02" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "output_refs" => ["TST_BUS_01"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_03" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_02"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_HP_04" => Dict{String,Any}(
+            "type" => "HeatPump",
+            "m_heat_in" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_03"],
+            "power_th" => 9000,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_01_ELY_01" => Dict{String,Any}(
+            "type" => "Electrolyser",
+            "output_refs" => ["TST_BUS_00",
+                              "TST_GRI_H2",
+                              "TST_GRI_O2"],
+            "m_heat_ht_out" => "m_h_w_lt1",
+            "output_temperature" => 45,
+            "power_el" => 40000,
+            "heat_lt_is_usable" => false,
+            "nr_switchable_units" => 4,
+            "dispatch_strategy" => "equal_with_mpf",
+            "min_power_fraction_total" => 0.0,
+            "min_power_fraction" => 0.0,
+        ),
+        "TST_BUS_00" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_lt1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
+                "output_order" => ["TST_HP_02", "TST_HP_01"],
+                "energy_flow" => [[1, 1],
+                                  [1, 1]],
             ),
-            "TST_DEM_02" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 90,
-                "scale" => 500
+        ),
+        "TST_BUS_01" => Dict{String,Any}(
+            "type" => "Bus",
+            "medium" => "m_h_w_ht1",
+            "connections" => Dict{String,Any}(
+                "input_order" => ["TST_HP_01b", "TST_HP_02"],
+                "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01"],
+                "energy_flow" => [[1, 0, 1],
+                                  [1, 0, 1]],
             ),
-            "TST_DEM_03" => Dict{String,Any}(
-                "type" => "Demand",
-                "medium" => "m_h_w_ht1",
-                "output_refs" => [],
-                "energy_profile_file_path" => "./profiles/examples/general/dem_heat_nrg_var_hi-amp.prf",
-                "constant_temperature" => 95,
-                "scale" => 500
-            ),
-            "TST_GRI_H2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_h2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_GRI_O2" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_c_g_o2",
-                "input_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => false
-            ),
-            "TST_SRC_01" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_h_w_lt1",
-                "output_refs" => [
-                    "TST_BUS_00"
-                ],
-                "max_power_profile_file_path" => "./profiles/examples/general/src_heat_maxpow_var_lo-amp.prf",
-                "temperature_profile_file_path" => "./profiles/examples/general/src_heat_temp_var_avg25.prf",
-                "scale" => 1000
-            ),
-            "TST_GRI_00" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_01_ELY_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_01" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01"
-                ],
-                "is_source" => true
-            ),
-            "TST_SRC_1b" => Dict{String,Any}(
-                "type" => "BoundedSupply",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "is_source" => true,
-                "constant_power" => 400
-            ),
-            "TST_GRI_02" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_02"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_03" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_03"
-                ],
-                "is_source" => true
-            ),
-            "TST_GRI_04" => Dict{String,Any}(
-                "type" => "GridConnection",
-                "medium" => "m_e_ac_230v",
-                "output_refs" => [
-                    "TST_HP_04"
-                ],
-                "is_source" => true
-            ),
-    
-            "TST_HP_01" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_HP_01b"
-                ],
-                "power_th" => 1200,
-                "output_temperature" => 60,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_01b" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_02" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "output_refs" => [
-                    "TST_BUS_01"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_03" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_02"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_HP_04" => Dict{String,Any}(
-                "type" => "HeatPump",
-                "m_heat_in" => "m_h_w_ht1",
-                "output_refs" => [
-                    "TST_DEM_03"
-                ],
-                "power_th" => 9000,
-                "min_power_fraction" => 0.0
-            ),
-    
-            "TST_01_ELY_01" => Dict{String,Any}(
-                "type" => "Electrolyser",
-                "output_refs" => [
-                    "TST_BUS_00",
-                    "TST_GRI_H2",
-                    "TST_GRI_O2"
-                ],
-                "m_heat_ht_out" => "m_h_w_lt1",
-                "output_temperature" => 45,
-                "power_el" => 40000,
-                "heat_lt_is_usable" => false,
-                "nr_switchable_units" => 4,
-                "dispatch_strategy" => "equal_with_mpf",
-                "min_power_fraction_total" => 0.0,
-                "min_power_fraction" => 0.0
-            ),
-            "TST_BUS_00" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_lt1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_01_ELY_01", "TST_SRC_01"],
-                    "output_order" => ["TST_HP_02", "TST_HP_01"],
-                    "energy_flow" => [[1, 1],
-                                      [1, 1]]
-                    )
-            ),
-            "TST_BUS_01" => Dict{String,Any}(
-                "type" => "Bus",
-                "medium" => "m_h_w_ht1",
-                "connections" => Dict{String,Any}(
-                    "input_order" => ["TST_HP_01b", "TST_HP_02"],
-                    "output_order" => ["TST_HP_03", "TST_HP_04", "TST_DEM_01" ],
-                    "energy_flow" => [[1, 0, 1],
-                                      [1, 0, 1]]
-                )
-            )
+        ),
     )
 
     simulation_parameters = Dict{String,Any}(
         "time_step_seconds" => 900,
         "time" => 0,
         "epsilon" => 1e-9,
-        "is_first_timestep" => true
+        "is_first_timestep" => true,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
 
-    expected_bus1 = Set([
-        components["TST_BUS_00"],
-    ])
-    expected_bus2 = Set([
-        components["TST_BUS_01"],
-    ])
-    expected_transformer1 = Set([
-        components["TST_HP_01"],
-        components["TST_HP_01b"],
-        components["TST_HP_02"],
-        components["TST_HP_03"],
-        components["TST_01_ELY_01"],
-    ])
-    expected_transformer2 = Set([
-        components["TST_HP_04"],
+    expected_bus1 = Set([components["TST_BUS_00"]])
+    expected_bus2 = Set([components["TST_BUS_01"]])
+    expected_transformer1 = Set([components["TST_HP_01"],
+                                 components["TST_HP_01b"],
+                                 components["TST_HP_02"],
+                                 components["TST_HP_03"],
+                                 components["TST_01_ELY_01"]])
+    expected_transformer2 = Set([components["TST_HP_04"]])
 
-    ])
+    chains_bus = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                   EnergySystems.sf_bus)
 
-    chains_bus = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_bus
-    )
-
-    chains_transformer = Resie.find_chains(
-        [u for u in values(components) if !startswith(u.uac, "Proxy")],
-        EnergySystems.sf_transformer,
-        direct_connection_only=false
-    )
+    chains_transformer = Resie.find_chains([u for u in values(components) if !startswith(u.uac, "Proxy")],
+                                           EnergySystems.sf_transformer;
+                                           direct_connection_only=false)
 
     @test length(chains_bus) == 2
     @test chains_bus[1] == expected_bus1
@@ -991,16 +863,22 @@ function test_find_indirect_chains_denied2()
     @test Resie.distance_to_sink(components["TST_HP_03"], EnergySystems.sf_transformer, [], "") == 0
     @test Resie.distance_to_sink(components["TST_HP_04"], EnergySystems.sf_transformer, [], "") == 0
     @test Resie.distance_to_sink(components["TST_01_ELY_01"], EnergySystems.sf_transformer, [], "") == 5
-    
-    # test function to determine if transformers are at interfaces, considers energy flow matrix of bus
-    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out], "output") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out], "output") == false
-    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in], "input") == true
-    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in], "input") == false
 
+    # test function to determine if transformers are at interfaces, considers energy flow matrix of bus
+    @test Resie.check_interface_for_transformer(components["TST_HP_02"].output_interfaces[components["TST_HP_02"].m_heat_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].output_interfaces[components["TST_HP_01b"].m_heat_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_01b"].input_interfaces[components["TST_HP_01b"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_01_ELY_01"].output_interfaces[components["TST_01_ELY_01"].m_heat_ht_out],
+                                                "output") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].output_interfaces[components["TST_HP_03"].m_heat_out],
+                                                "output") == false
+    @test Resie.check_interface_for_transformer(components["TST_HP_03"].input_interfaces[components["TST_HP_03"].m_heat_in],
+                                                "input") == true
+    @test Resie.check_interface_for_transformer(components["TST_HP_04"].input_interfaces[components["TST_HP_04"].m_heat_in],
+                                                "input") == false
 end
 
 @testset "find_chains" begin
@@ -1012,30 +890,22 @@ end
 
 function test_find_indexes()
     # normal case
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    own_idx, target_idx = Resie.find_indexes(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    own_idx, target_idx = Resie.find_indexes(steps,
+                                             ("TST_BUS_02", EnergySystems.s_control),
+                                             ("TST_BUS_01", EnergySystems.s_control))
     @test own_idx == 1
     @test target_idx == 3
 
     # can't find either step due to wrong UAC in one case and wrong step in the other
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    own_idx, target_idx = Resie.find_indexes(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_process),
-        ("TST_BSS_01", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    own_idx, target_idx = Resie.find_indexes(steps,
+                                             ("TST_BUS_02", EnergySystems.s_process),
+                                             ("TST_BSS_01", EnergySystems.s_control))
     @test own_idx === nothing
     @test target_idx === nothing
 end
@@ -1046,47 +916,35 @@ end
 
 function test_place_one_higher()
     # normal test case
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_higher!(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_higher!(steps,
+                            ("TST_BUS_02", EnergySystems.s_control),
+                            ("TST_BUS_01", EnergySystems.s_control))
     @test steps[1] == [2, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [4, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [3, ("TST_BUS_01", EnergySystems.s_control)]
 
     # priority already is higher and force was not used => no change
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [4, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_higher!(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [4, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_higher!(steps,
+                            ("TST_BUS_02", EnergySystems.s_control),
+                            ("TST_BUS_01", EnergySystems.s_control))
     @test steps[1] == [2, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [3, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [4, ("TST_BUS_01", EnergySystems.s_control)]
 
     # priority already is higher and force was used => works as normal
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [4, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_higher!(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        force=true
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [4, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_higher!(steps,
+                            ("TST_BUS_02", EnergySystems.s_control),
+                            ("TST_BUS_01", EnergySystems.s_control);
+                            force=true)
     @test steps[1] == [2, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [4, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [3, ("TST_BUS_01", EnergySystems.s_control)]
@@ -1098,47 +956,35 @@ end
 
 function test_place_one_lower()
     # normal test case
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_lower!(
-        steps,
-        ("TST_BUS_02", EnergySystems.s_control),
-        ("TST_BUS_03", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_lower!(steps,
+                           ("TST_BUS_02", EnergySystems.s_control),
+                           ("TST_BUS_03", EnergySystems.s_control))
     @test steps[1] == [2, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [1, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [0, ("TST_BUS_01", EnergySystems.s_control)]
 
     # priority already is lower and force was not used => no change
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_lower!(
-        steps,
-        ("TST_BUS_03", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control)
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_lower!(steps,
+                           ("TST_BUS_03", EnergySystems.s_control),
+                           ("TST_BUS_01", EnergySystems.s_control))
     @test steps[1] == [2, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [3, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [1, ("TST_BUS_01", EnergySystems.s_control)]
 
     # priority already is lower and force was used => works as normal
-    steps = [
-        [2, ("TST_BUS_02", EnergySystems.s_control)],
-        [3, ("TST_BUS_03", EnergySystems.s_control)],
-        [1, ("TST_BUS_01", EnergySystems.s_control)],
-    ]
-    Resie.place_one_lower!(
-        steps,
-        ("TST_BUS_03", EnergySystems.s_control),
-        ("TST_BUS_01", EnergySystems.s_control),
-        force=true
-    )
+    steps = [[2, ("TST_BUS_02", EnergySystems.s_control)],
+             [3, ("TST_BUS_03", EnergySystems.s_control)],
+             [1, ("TST_BUS_01", EnergySystems.s_control)]]
+    Resie.place_one_lower!(steps,
+                           ("TST_BUS_03", EnergySystems.s_control),
+                           ("TST_BUS_01", EnergySystems.s_control);
+                           force=true)
     @test steps[1] == [1, ("TST_BUS_02", EnergySystems.s_control)]
     @test steps[2] == [3, ("TST_BUS_03", EnergySystems.s_control)]
     @test steps[3] == [2, ("TST_BUS_01", EnergySystems.s_control)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,13 +9,11 @@ log_to_file = false
 general_logfile_path = "output/logfile_general.log"
 balanceWarn_logfile_path = "output/logfile_balanceWarn.log"
 min_log_level = Resie_Logger.Logging.Debug
-log_file_general, log_file_balanceWarn = Resie_Logger.start_logger(
-    log_to_console,
-    log_to_file,
-    general_logfile_path,
-    balanceWarn_logfile_path,
-    min_log_level
-)
+log_file_general, log_file_balanceWarn = Resie_Logger.start_logger(log_to_console,
+                                                                   log_to_file,
+                                                                   general_logfile_path,
+                                                                   balanceWarn_logfile_path,
+                                                                   min_log_level)
 
 @testset "tests_are_working" begin
     @test true

--- a/test/scenarios/cli.jl
+++ b/test/scenarios/cli.jl
@@ -25,12 +25,10 @@ include("../../src/resie_logger.jl")
 using .Resie_Logger
 using Resie
 
-KNOWN_COMMANDS = Set([
-    "generate_output",
-    "set_reference",
-    "compare_ooo",
-    "rebuild_overview"
-])
+KNOWN_COMMANDS = Set(["generate_output",
+                      "set_reference",
+                      "compare_ooo",
+                      "rebuild_overview"])
 
 """
     setup_logger(subdir)
@@ -52,13 +50,13 @@ function setup_logger(subdir)
     general_logfile_path = joinpath(subdir, "general.log")
     balanceWarn_logfile_path = joinpath(subdir, "balanceWarn.log")
     min_log_level = Resie_Logger.Logging.Debug
-    log_file_general, log_file_balanceWarn = Resie_Logger.start_logger(
-        log_to_console,
-        log_to_file,
-        general_logfile_path,
-        balanceWarn_logfile_path,
-        min_log_level
-    )
+
+    log_file_general,
+    log_file_balanceWarn = Resie_Logger.start_logger(log_to_console,
+                                                     log_to_file,
+                                                     general_logfile_path,
+                                                     balanceWarn_logfile_path,
+                                                     min_log_level)
     @info "Logging set up"
     return log_file_general, log_file_balanceWarn
 end
@@ -85,10 +83,7 @@ function compare_files(file_1, file_2)
     differences = []
 
     if length(lines_1) != length(lines_2)
-        push!(
-            differences,
-            (0, "Different number of lines: $(length(lines_1))|$(length(lines_2))")
-        )
+        push!(differences, (0, "Different number of lines: $(length(lines_1))|$(length(lines_2))"))
     end
 
     for i in 1:min(length(lines_1), length(lines_2))
@@ -142,10 +137,7 @@ function generate_output(name::String, subdir::String)
     components = nothing
     try
         if sim_params !== nothing && project_config !== nothing
-            components = Resie.load_components(
-                project_config["components"],
-                sim_params
-            )
+            components = Resie.load_components(project_config["components"], sim_params)
             print("|  ✓  ")
         else
             print("|     ")
@@ -158,14 +150,12 @@ function generate_output(name::String, subdir::String)
     step_order = nothing
     try
         if project_config !== nothing && components !== nothing
-            if (
-                haskey(project_config, "order_of_operation")
-                && length(project_config["order_of_operation"]) > 0
-            )
-                step_order = Resie.load_order_of_operations(
-                    project_config["order_of_operation"],
-                    components
-                )
+            if (haskey(project_config, "order_of_operation")
+                &&
+                length(project_config["order_of_operation"]) > 0)
+                # end of condition
+                step_order = Resie.load_order_of_operations(project_config["order_of_operation"],
+                                                            components)
             else
                 step_order = Resie.calculate_order_of_operations(components)
             end
@@ -178,12 +168,11 @@ function generate_output(name::String, subdir::String)
         print("|  X  ")
     end
 
-    if (
-        project_config !== nothing
+    if (project_config !== nothing
         && sim_params !== nothing
         && components !== nothing
-        && step_order !== nothing
-    )
+        && step_order !== nothing)
+        # end of condition
         Resie.run_simulation_loop(project_config, sim_params, components, step_order)
         print("|  ✓  ")
     else
@@ -206,13 +195,11 @@ Set the reference outputs by copying relevant output files.
 -`subdir::String`: Full path of the subdir for the scenario
 """
 function set_reference(name, subdir)
-    outputs_to_set = [
-        "auxiliary_info.md",
-        "balanceWarn.log",
-        "out.csv",
-        "output_plot.html",
-        "sankey_plot.html"
-    ]
+    outputs_to_set = ["auxiliary_info.md",
+                      "balanceWarn.log",
+                      "out.csv",
+                      "output_plot.html",
+                      "sankey_plot.html"]
 
     println("Setting reference outputs for scenario $name")
 
@@ -221,7 +208,7 @@ function set_reference(name, subdir)
         ref_file_path = joinpath(subdir, "ref_" * file_name)
 
         if isfile(output_file_path)
-            cp(output_file_path, ref_file_path, force=true)
+            cp(output_file_path, ref_file_path; force=true)
         end
     end
 end
@@ -238,10 +225,8 @@ Compare the order of operations between the reference and output files.
 function compare_ooo(name, subdir)
     print("Comparing order of operations for scenario $name: ")
 
-    differences = compare_files(
-        joinpath(subdir, "auxiliary_info.md"),
-        joinpath(subdir, "ref_auxiliary_info.md")
-    )
+    differences = compare_files(joinpath(subdir, "auxiliary_info.md"),
+                                joinpath(subdir, "ref_auxiliary_info.md"))
 
     if length(differences) == 0
         print("✓\n")
@@ -266,22 +251,18 @@ Rebuild the overview HTML page for the scenario outputs.
 function rebuild_overview(scenarios_dir)
     println("Rebuilding overview in dir $scenarios_dir")
 
-    main_outputs = [
-        "output_plot.html",
-        "ref_output_plot.html",
-        "sankey_plot.html",
-        "ref_sankey_plot.html",
-    ]
-    other_files = [
-        "auxiliary_info.md",
-        "balanceWarn.log",
-        "general.log",
-        "inputs.json",
-        "out.csv",
-        "ref_auxiliary_info.md",
-        "ref_balanceWarn.log",
-        "ref_out.csv",
-    ]
+    main_outputs = ["output_plot.html",
+                    "ref_output_plot.html",
+                    "sankey_plot.html",
+                    "ref_sankey_plot.html"]
+    other_files = ["auxiliary_info.md",
+                   "balanceWarn.log",
+                   "general.log",
+                   "inputs.json",
+                   "out.csv",
+                   "ref_auxiliary_info.md",
+                   "ref_balanceWarn.log",
+                   "ref_out.csv"]
 
     scenarios_list_html = ""
     for name in readdir(scenarios_dir)

--- a/test/tests_control.jl
+++ b/test/tests_control.jl
@@ -20,16 +20,14 @@ function setup_control_tests()
         "TST_HP_01" => Dict{String,Any}(
             "type" => "HeatPump",
             "output_refs" => ["TST_BT_01"],
-            "control_modules" => [
-                Dict{String,Any}(
-                    "name" => "storage_driven",
-                    "high_threshold" => 0.9,
-                    "low_threshold" => 0.2,
-                    "storage_uac" => "TST_BT_01"  
-                )
-            ],
+            "control_modules" => [Dict{String,Any}(
+                                      "name" => "storage_driven",
+                                      "high_threshold" => 0.9,
+                                      "low_threshold" => 0.2,
+                                      "storage_uac" => "TST_BT_01",
+                                  )],
             "power_th" => 20000,
-            "constant_cop" => 3.0
+            "constant_cop" => 3.0,
         ),
         "TST_BT_01" => Dict{String,Any}(
             "type" => "BufferTank",
@@ -50,7 +48,7 @@ function setup_control_tests()
     simulation_params = Dict{String,Any}(
         "time" => 0,
         "time_step_seconds" => 900,
-        "epsilon" => 1e-9
+        "epsilon" => 1e-9,
     )
 
     components = Resie.load_components(components_config, simulation_params)


### PR DESCRIPTION
Changes are from applying the formatter on files of tests and those for heat pump and efficiency calculations. Changes have been skimmed and confirmed to not be too terrible. A review is not required and this branch and PR serve the purpose of not cluttering the actual code review with changes from the formatter.