### PR TITLE
Fix bug in ooo with grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ In general the development follows the [semantic versioning](https://semver.org/
 ## Pre-1.0-releases
 As per the definition of semantic versioning and the reality of early development, in versions prior to 1.0.0 any release might break compatability. To alleviate this somewhat, the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some breaking changes may slip beneath notice.
 
+### Version 0.10.1
+* Bugfix for order of operation not determining middle busses with grids correctly
+* Bugfix in grid (sink) setting wrong min/max temperature in control
+
 ### Version 0.10.0
 * Change handling and definition of timesteps by introducing datetime indexes for profiles and for internal handling:
   * Profile values in ReSiE are now defined as the mean/sum of the timespan following the current timestep. This affects mainly the weather data from a global weather file. If this is not used, any definition can be used, the provided profiles just have to be consistent.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Resie"
 uuid = "2e0f99b1-0d8f-4296-8d0c-1c50a50d04c8"
 authors = ["Maksim Helmann <maksim.helmann@siz-energieplus.de>", "Etienne Ott <etienne.ott@siz-energieplus.de>", "Heiner Steinacker <heiner.steinacker@siz-energieplus.de>", "Adrian Vollmer <adrian.vollmer@siz-energieplus.de>"]
-version = "0.9.4"
+version = "0.10.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/energy_systems/connections/grid_connection.jl
+++ b/src/energy_systems/connections/grid_connection.jl
@@ -78,8 +78,8 @@ function control(unit::GridConnection,
     else
         set_max_energy!(unit.input_interfaces[unit.medium], Inf)
         set_temperature!(unit.input_interfaces[unit.medium],
-                         nothing,
-                         unit.temperature)
+                         unit.temperature,
+                         nothing)
     end
 end
 


### PR DESCRIPTION
Version bump to v0.10.1 with the following changes:
* Bugfix for order of operation not determining middle busses with grids correctly
* Bugfix in grid (sink) setting wrong min/max temperature in control