### PR TITLE
Refactor global state and helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ In general the development follows the [semantic versioning](https://semver.org/
 ## Pre-1.0-releases
 As per the definition of semantic versioning and the reality of early development, in versions prior to 1.0.0 any release might break compatability. To alleviate this somewhat, the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some breaking changes may slip beneath notice.
 
+### Version 0.10.2
+* Internal changes concerning global state in the package scope:
+  * Moving helper functions watt_to_wh and wh_to_watts into the simulation parameters
+  * Providing access to the instances of a run via a package-global registry
+
 ### Version 0.10.1
 * Bugfix for order of operation not determining middle busses with grids correctly
 * Bugfix in grid (sink) setting wrong min/max temperature in control

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Resie"
 uuid = "2e0f99b1-0d8f-4296-8d0c-1c50a50d04c8"
 authors = ["Maksim Helmann <maksim.helmann@siz-energieplus.de>", "Etienne Ott <etienne.ott@siz-energieplus.de>", "Heiner Steinacker <heiner.steinacker@siz-energieplus.de>", "Adrian Vollmer <adrian.vollmer@siz-energieplus.de>"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/Project.toml
+++ b/Project.toml
@@ -18,3 +18,7 @@ Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+UUIDs = "1.11.0"

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -1,5 +1,43 @@
 module Resie
 
+using UUIDs
+
+"""
+Contains the parameters, instantiated components and the order of operations for a simulation run.
+
+In short, it bundles all the data required to perform a simulation from start to finish.
+Through its fields it contains a lot of complexity in terms of hierarchical data structures.
+However the struct should not be used as argument for complex calculations. Instead it is
+intended to be used for the run registry only.
+
+Because the types used to represent the field are defined in modules that depend upon the
+definition of the struct in the first place, the fields are defined with the generic 'Any'
+type.
+"""
+mutable struct SimulationRun
+    parameters::Dict{String,Any}
+    components::Dict{String,Any}
+    order_of_operations::Vector{Any}
+end
+
+# this registry should be the only global state in the package and contains the state for
+# ongoing or paused simulation runs
+current_runs::Dict{UUID,SimulationRun} = Dict{UUID,SimulationRun}()
+
+"""
+    get_run(id)
+
+Get the simulation run container for the given ID.
+
+# Args
+- `id::UUID`: The ID of the run
+# Returns
+- `SimulationRun`: The simulation run container
+"""
+function get_run(id::UUID)::SimulationRun
+    return current_runs[id]
+end
+
 # note: includes that contain their own module, which have to be submodules of the Resie
 # module, are included first, then can be accessed with the "using" keyword. files that
 # contain code that is intended to be used in-place of their include statement (as part
@@ -27,28 +65,9 @@ using Colors
 using Interpolations
 using JSON
 using Dates
-using UUIDs
 
 const HOURS_PER_SECOND::Float64 = 1.0 / 3600.0
 const SECONDS_PER_HOUR::Float64 = 3600.0
-
-"""
-Contains the parameters, instantiated components and the order of operations for a simulation run.
-
-In short, it bundles all the data required to perform a simulation from start to finish.
-Through its fields it contains a lot of complexity in terms of hierarchical data structures.
-However the struct should not be used as argument for complex calculations. Instead it is
-mainly used for indexing the various sub data structures.
-"""
-mutable struct SimulationRun
-    parameters::Dict{String,Any}
-    components::Grouping
-    order_of_operations::StepInstructions
-end
-
-# these variables should be the only global state in the package and contain the state for
-# ongoing or paused simulation runs
-current_runs::Dict{UUID,SimulationRun} = Dict{UUID,SimulationRun}()
 
 """
     get_simulation_params(project_config)

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -62,7 +62,7 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
         return watts * time_step * HOURS_PER_SECOND
     end
     sim_params["wh_to_watts"] = function (wh::Float64)
-        return wh * time_step * SECONDS_PER_HOUR
+        return wh * SECONDS_PER_HOUR / time_step
     end
 
     weather_file_path = default(project_config["simulation_parameters"],

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -27,9 +27,28 @@ using Colors
 using Interpolations
 using JSON
 using Dates
+using UUIDs
 
 const HOURS_PER_SECOND::Float64 = 1.0 / 3600.0
 const SECONDS_PER_HOUR::Float64 = 3600.0
+
+"""
+Contains the parameters, instantiated components and the order of operations for a simulation run.
+
+In short, it bundles all the data required to perform a simulation from start to finish.
+Through its fields it contains a lot of complexity in terms of hierarchical data structures.
+However the struct should not be used as argument for complex calculations. Instead it is
+mainly used for indexing the various sub data structures.
+"""
+mutable struct SimulationRun
+    parameters::Dict{String,Any}
+    components::Grouping
+    order_of_operations::StepInstructions
+end
+
+# these variables should be the only global state in the package and contain the state for
+# ongoing or paused simulation runs
+current_runs::Dict{UUID,SimulationRun} = Dict{UUID,SimulationRun}()
 
 """
     get_simulation_params(project_config)
@@ -250,6 +269,10 @@ function load_and_run(filepath::String)
     end
 
     sim_params, components, step_order = prepare_inputs(project_config)
+    run_ID = uuid1()
+    sim_params["run_ID"] = run_ID
+    current_runs[run_ID] = SimulationRun(sim_params, components, step_order)
+
     run_simulation_loop(project_config, sim_params, components, step_order)
 end
 

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -28,6 +28,9 @@ using Interpolations
 using JSON
 using Dates
 
+const HOURS_PER_SECOND::Float64 = 1.0 / 3600.0
+const SECONDS_PER_HOUR::Float64 = 3600.0
+
 """
     get_simulation_params(project_config)
 
@@ -52,6 +55,15 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
         "latitude" => default(project_config["simulation_parameters"], "latitude", nothing),
         "longitude" => default(project_config["simulation_parameters"], "longitude", nothing),
     )
+
+    # add helper functions to convert power to work and vice-versa. this uses the time step
+    # of the simulation as the duration required for the conversion.
+    sim_params["watt_to_wh"] = function (watts::Float64)
+        return watts * time_step * HOURS_PER_SECOND
+    end
+    sim_params["wh_to_watts"] = function (wh::Float64)
+        return wh * time_step * SECONDS_PER_HOUR
+    end
 
     weather_file_path = default(project_config["simulation_parameters"],
                                 "weather_file_path",

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -100,10 +100,6 @@ Construct and prepare parameters, energy system components and the order of oper
 function prepare_inputs(project_config::Dict{AbstractString,Any})
     sim_params = get_simulation_params(project_config)
 
-    # this sets a global variable in the EnergySystems module, which is required for a
-    # utility function to work properly
-    EnergySystems.set_timestep(sim_params["time_step_seconds"])
-
     components = load_components(project_config["components"], sim_params)
 
     if haskey(project_config, "order_of_operation") && length(project_config["order_of_operation"]) > 0

--- a/src/energy_systems/base.jl
+++ b/src/energy_systems/base.jl
@@ -34,38 +34,6 @@ default(config::Dict{String,Any}, name::String, default_val::Any)::Any = return 
                                                                                 default_val
 
 """
-The number of hours per time step, used by various utility functions.
-"""
-HOURS_PER_TIME_STEP::Float64 = 0.0
-
-"""
-Update the time step, in seconds.
-"""
-function set_timestep(step_seconds::Integer)
-    global HOURS_PER_TIME_STEP = Float64(step_seconds) / 3600.0
-end
-
-"""
-Calculate energy from power by using the simulation time step.
-
-This function must be assigned a method after simulation parameters (such as the timestep)
-have been loaded.
-"""
-function watt_to_wh(watts::Float64)
-    return watts * HOURS_PER_TIME_STEP
-end
-
-"""
-Calculate power from energy by using the simulation time step.
-
-This function must be assigned a method after simulation parameters (such as the timestep)
-have been loaded.
-"""
-function wh_to_watts(wh::Float64)
-    return wh / HOURS_PER_TIME_STEP
-end
-
-"""
 Categories that each represent a physical medium in conjunction with additional attributes,
 such as temperature or voltage. These attributes are not necessarily unchanging, but are
 considered the nominal range. For example, a heating component might circulate water anywhere

--- a/src/energy_systems/efficiency.jl
+++ b/src/energy_systems/efficiency.jl
@@ -98,7 +98,8 @@ function create_plr_lookup_tables(unit::PLRDEComponent, sim_params::Dict{String,
     for name in unit.interface_list
         lookup_table = []
         for plr in collect(0.0:(unit.discretization_step):1.0)
-            push!(lookup_table, (watt_to_wh(unit.power) * plr * unit.efficiencies[name](plr),
+            push!(lookup_table, (sim_params["watt_to_wh"](unit.power) * plr *
+                                 unit.efficiencies[name](plr),
                                  plr))
         end
         tables[name] = lookup_table
@@ -138,15 +139,17 @@ is performed to calculate the corresponding PLR.
 - `interface::Symbol`: The interface to which the energy value corresponds. This should be
     one of the names defined in field `interface_list` of the component.
 - `energy_value::Float64`: The energy value
+- `w2wh::Function`: Function to convert power to work
 # Returns
 - `Float64`: The part load ratio (from 0.0 to 1.0) as inverse from the energy value
 """
 function plr_from_energy(unit::PLRDEComponent,
                          interface::Symbol,
-                         energy_value::Float64)::Float64
+                         energy_value::Float64,
+                         w2wh::Function)::Float64
     # shortcut if the given interface is designated as linear in respect to PLR
     if interface === unit.linear_interface
-        return energy_value / watt_to_wh(unit.power)
+        return energy_value / w2wh(unit.power)
     end
 
     lookup_table = unit.energy_to_plr[interface]
@@ -193,22 +196,24 @@ Calculates the energy value for the given interface from the given PLR.
 - `interface::Symbol`: The interface to which the energy value corresponds. This should be
     one of the names defined in field `interface_list` of the component.
 - `plr::Float64`: The part load ratio, should be between 0.0 and 1.0
+- `w2wh::Function`: Function to convert power to work
 # Returns
 - `Float64`: The energy value
 """
 function energy_from_plr(unit::PLRDEComponent,
                          interface::Symbol,
-                         plr::Float64)::Float64
+                         plr::Float64,
+                         w2wh::Function)::Float64
     # the intuitive solution would be to multiply the power with the part load ratio and the
     # the efficiency at that PLR, but for unknown reasons this introduces an error in the
     # linear interpolation that appears to be quadratic in the distance to the support
     # values
     # @TODO: Investigate this further for improved performance
-    # return plr * watt_to_wh(unit.power) * unit.efficiencies[interface](plr)
+    # return plr * w2wh(unit.power) * unit.efficiencies[interface](plr)
 
     # shortcut if the given interface is designated as linear in respect to PLR
     if interface === unit.linear_interface
-        return plr * watt_to_wh(unit.power)
+        return plr * w2wh(unit.power)
     end
 
     lookup_table = unit.energy_to_plr[interface]
@@ -281,11 +286,11 @@ function calculate_energies_for_plrde(unit::PLRDEComponent,
         energy = abs(energy)
 
         # limit to design power
-        energy = min(watt_to_wh(unit.power) * unit.efficiencies[name](1.0),
+        energy = min(sim_params["watt_to_wh"](unit.power) * unit.efficiencies[name](1.0),
                      energy)
 
         push!(available_energy, energy)
-        push!(plr_from_nrg, plr_from_energy(unit, name, energy))
+        push!(plr_from_nrg, plr_from_energy(unit, name, energy, sim_params["watt_to_wh"]))
     end
 
     # the operation point of the component is the minimum of the PLR from all inputs/outputs
@@ -298,7 +303,7 @@ function calculate_energies_for_plrde(unit::PLRDEComponent,
 
     energies = []
     for name in unit.interface_list
-        push!(energies, energy_from_plr(unit, name, used_plr))
+        push!(energies, energy_from_plr(unit, name, used_plr, sim_params["watt_to_wh"]))
     end
     return (true, energies)
 end

--- a/src/energy_systems/general/bounded_sink.jl
+++ b/src/energy_systems/general/bounded_sink.jl
@@ -61,7 +61,7 @@ function control(unit::BoundedSink,
     update(unit.controller)
 
     if unit.constant_power !== nothing
-        unit.max_energy = watt_to_wh(unit.constant_power)
+        unit.max_energy = sim_params["watt_to_wh"](unit.constant_power)
     elseif unit.max_power_profile !== nothing
         unit.max_energy = unit.scaling_factor * Profiles.work_at_time(unit.max_power_profile, sim_params)
     else

--- a/src/energy_systems/general/bounded_supply.jl
+++ b/src/energy_systems/general/bounded_supply.jl
@@ -61,7 +61,7 @@ function control(unit::BoundedSupply,
     update(unit.controller)
 
     if unit.constant_power !== nothing
-        unit.max_energy = watt_to_wh(unit.constant_power)
+        unit.max_energy = sim_params["watt_to_wh"](unit.constant_power)
     elseif unit.max_power_profile !== nothing
         unit.max_energy = unit.scaling_factor * Profiles.work_at_time(unit.max_power_profile, sim_params)
     else

--- a/src/energy_systems/general/fixed_sink.jl
+++ b/src/energy_systems/general/fixed_sink.jl
@@ -64,7 +64,7 @@ function control(unit::FixedSink,
     update(unit.controller)
 
     if unit.constant_demand !== nothing
-        unit.demand = watt_to_wh(unit.constant_demand)
+        unit.demand = sim_params["watt_to_wh"](unit.constant_demand)
     elseif unit.energy_profile !== nothing
         unit.demand = unit.scaling_factor * Profiles.work_at_time(unit.energy_profile, sim_params)
     else

--- a/src/energy_systems/general/fixed_supply.jl
+++ b/src/energy_systems/general/fixed_supply.jl
@@ -64,7 +64,7 @@ function control(unit::FixedSupply,
     update(unit.controller)
 
     if unit.constant_supply !== nothing
-        unit.supply = watt_to_wh(unit.constant_supply)
+        unit.supply = sim_params["watt_to_wh"](unit.constant_supply)
     elseif unit.energy_profile !== nothing
         unit.supply = unit.scaling_factor * Profiles.work_at_time(unit.energy_profile, sim_params)
     else

--- a/src/energy_systems/heat_sources/generic_heat_source.jl
+++ b/src/energy_systems/heat_sources/generic_heat_source.jl
@@ -86,7 +86,7 @@ function control(unit::GenericHeatSource,
     update(unit.controller)
 
     if unit.constant_power !== nothing
-        unit.max_energy = watt_to_wh(unit.constant_power)
+        unit.max_energy = sim_params["watt_to_wh"](unit.constant_power)
     elseif unit.max_power_profile !== nothing
         unit.max_energy = unit.scaling_factor * Profiles.work_at_time(unit.max_power_profile, sim_params)
     else

--- a/src/energy_systems/heat_sources/geothermal_probes.jl
+++ b/src/energy_systems/heat_sources/geothermal_probes.jl
@@ -202,9 +202,10 @@ function initialise!(unit::GeothermalProbes, sim_params::Dict{String,Any})
     unit.g_function, unit.number_of_probes, unit.probe_coordinates = calculate_g_function(unit, sim_params)
 
     # calculate max energies
-    unit.max_output_energy = watt_to_wh(unit.max_output_power * unit.probe_depth * unit.number_of_probes)
+    unit.max_output_energy = sim_params["watt_to_wh"](unit.max_output_power * unit.probe_depth * unit.number_of_probes)
     if unit.regeneration
-        unit.max_input_energy = watt_to_wh(unit.max_input_power * unit.probe_depth * unit.number_of_probes)
+        unit.max_input_energy = sim_params["watt_to_wh"](unit.max_input_power * unit.probe_depth *
+                                                         unit.number_of_probes)
     end
 end
 
@@ -838,7 +839,7 @@ function calculate_new_fluid_temperature(unit::GeothermalProbes, wh2w::Function)
         unit.power_in_out_difference_per_probe_meter[unit.time_index] = wh2w(unit.energy_in_out_per_probe_meter[unit.time_index])
     else
         unit.power_in_out_difference_per_probe_meter[unit.time_index] = wh2w(unit.energy_in_out_per_probe_meter[unit.time_index] -
-                                                                                    unit.energy_in_out_per_probe_meter[unit.time_index - 1])
+                                                                             unit.energy_in_out_per_probe_meter[unit.time_index - 1])
     end
 
     current_temperature_difference = sum(reverse(unit.power_in_out_difference_per_probe_meter[1:(unit.time_index)]) .*

--- a/test/energy_systems/balance_and_distribution/bus_to_bus_distribution.jl
+++ b/test/energy_systems/balance_and_distribution/bus_to_bus_distribution.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_short_chain_distribution()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/many_plus_storage_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/many_plus_storage_to_one.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_many_plus_storage_to_one()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/many_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/many_to_many.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_many_to_many()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/many_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/many_to_one.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_many_to_one()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_bus_to_many_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_bus_to_many_bus.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_one_bus_to_many_bus()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_bus_to_one_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_bus_to_one_bus.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_one_bus_to_one_bus()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_plus_storage_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/one_plus_storage_to_many.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_one_plus_storage_to_many()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_to_many.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_many.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_many_to_one()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_to_one.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_one.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_one_to_one_grid()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/balance_and_distribution/one_to_one_via_bus.jl
+++ b/test/energy_systems/balance_and_distribution/one_to_one_via_bus.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../../test_util.jl")
 
 function test_one_to_one_via_bus()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/energy_system_from_storage.jl
+++ b/test/energy_systems/energy_system_from_storage.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function test_run_energy_system_from_storage()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/gasboiler_demand_driven_with_bus.jl
+++ b/test/energy_systems/gasboiler_demand_driven_with_bus.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function test_gasboiler_demand_driven_with_bus()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/heat_pump_demand_driven.jl
+++ b/test/energy_systems/heat_pump_demand_driven.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function test_heat_pump_demand_driven_correct_order()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/multiple_transformer_limited.jl
+++ b/test/energy_systems/multiple_transformer_limited.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function test_multiple_transformer_with_limitations()
     components_config = Dict{String,Any}(

--- a/test/energy_systems/plr_dependent_efficiency.jl
+++ b/test/energy_systems/plr_dependent_efficiency.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function get_demand_energy_system_config()
     return Dict{String,Any}(
@@ -66,31 +66,28 @@ function test_inverse_efficiency()
     components_config = get_demand_energy_system_config()
     components_config["TST_GB_01"]["nr_discretization_steps"] = 10
     eps = 1e-9
-    simulation_parameters = Dict{String,Any}(
-        "time_step_seconds" => 900,
-        "time" => 0,
-        "epsilon" => eps,
-    )
+    simulation_parameters = get_default_sim_params()
+    w2wh = simulation_parameters["watt_to_wh"]
 
     components = Resie.load_components(components_config, simulation_parameters)
     boiler = components["TST_GB_01"]
 
-    @test abs(plr_from_energy(boiler, Symbol("fuel_in"), 0.0)) < eps
-    @test abs(plr_from_energy(boiler, Symbol("fuel_in"), 1000.0) - 1.0) < eps
-    plr = plr_from_energy(boiler, Symbol("fuel_in"), 450.0)
+    @test abs(plr_from_energy(boiler, Symbol("fuel_in"), 0.0, w2wh)) < eps
+    @test abs(plr_from_energy(boiler, Symbol("fuel_in"), 1000.0, w2wh) - 1.0) < eps
+    plr = plr_from_energy(boiler, Symbol("fuel_in"), 450.0, w2wh)
     @test plr > 0.45 - eps && plr < 0.45 + eps
 
-    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 0.0)) < eps
-    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 1000.0) - 1.0) < eps
-    plr = plr_from_energy(boiler, Symbol("heat_out"), 450.0)
+    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 0.0, w2wh)) < eps
+    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 1000.0, w2wh) - 1.0) < eps
+    plr = plr_from_energy(boiler, Symbol("heat_out"), 450.0, w2wh)
     @test plr > 0.5614073352582631 - eps && plr < 0.5614073352582631 + eps
 
     boiler.discretization_step = 1.0 / 20
     EnergySystems.initialise!(boiler, simulation_parameters)
 
-    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 0.0)) < eps
-    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 1000.0) - 1.0) < eps
-    plr = plr_from_energy(boiler, Symbol("heat_out"), 450.0)
+    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 0.0, w2wh)) < eps
+    @test abs(plr_from_energy(boiler, Symbol("heat_out"), 1000.0, w2wh) - 1.0) < eps
+    plr = plr_from_energy(boiler, Symbol("heat_out"), 450.0, w2wh)
     @test plr > 0.561969105640274 - eps && plr < 0.561969105640274 + eps
 end
 
@@ -420,30 +417,31 @@ function test_electrolyser_dispatch_units()
     )
 
     simulation_parameters = get_default_sim_params()
+    w2wh = simulation_parameters["watt_to_wh"]
 
     components = Resie.load_components(components_config, simulation_parameters)
     electrolyser = components["TST_ELY_01"]
 
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0, w2wh)
     @test nr_units == 4
     @test isapprox(plr, 0.5, atol=1e-9)
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.31, Symbol("el_in"), 310.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.31, Symbol("el_in"), 310.0, w2wh)
     @test nr_units == 3
     @test isapprox(plr, 0.41333333333, atol=1e-9)
 
     electrolyser.dispatch_strategy = "all_equal"
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0, w2wh)
     @test nr_units == 4
     @test isapprox(plr, 0.5, atol=1e-9)
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.3, Symbol("el_in"), 300.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.3, Symbol("el_in"), 300.0, w2wh)
     @test nr_units == 4
     @test isapprox(plr, 0.3, atol=1e-9)
 
     electrolyser.dispatch_strategy = "try_optimal"
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.5, Symbol("el_in"), 500.0, w2wh)
     @test nr_units == 3
     @test isapprox(plr, 0.66666666666, atol=1e-9)
-    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.3, Symbol("el_in"), 300.0)
+    nr_units, plr = EnergySystems.dispatch_units(electrolyser, 0.3, Symbol("el_in"), 300.0, w2wh)
     @test nr_units == 2
     @test isapprox(plr, 0.6, atol=1e-9)
 end

--- a/test/energy_systems/storage_loading_switch.jl
+++ b/test/energy_systems/storage_loading_switch.jl
@@ -4,7 +4,7 @@ using Resie
 using Resie.EnergySystems
 using Resie.Profiles
 
-EnergySystems.set_timestep(900)
+include("../test_util.jl")
 
 function test_primary_producer_can_load_storage()
     components_config = Dict{String,Any}(

--- a/test/initialization/loading.jl
+++ b/test/initialization/loading.jl
@@ -3,6 +3,8 @@ using Test
 using Resie
 using Resie.EnergySystems
 
+include("../test_util.jl")
+
 function test_load_from_dict()
     components_config = Dict{String,Any}(
         "TST_GRI_01" => Dict{String,Any}(
@@ -44,11 +46,7 @@ function test_load_from_dict()
             "constant_temperature" => 60,
         ),
     )
-    simulation_params = Dict{String,Any}(
-        "time" => 0,
-        "time_step_seconds" => 900,
-        "epsilon" => 1e-9,
-    )
+    simulation_params = get_default_sim_params()
     components = Resie.load_components(components_config, simulation_params)
     @test length(keys(components)) == 5
     @test typeof(components["TST_BT_01"]) == Resie.EnergySystems.BufferTank
@@ -114,11 +112,7 @@ function test_load_custom_medium_categories()
             "medium" => "m_c_g_o2-impure",
         ),
     )
-    simulation_params = Dict{String,Any}(
-        "time" => 0,
-        "time_step_seconds" => 900,
-        "epsilon" => 1e-9,
-    )
+    simulation_params = get_default_sim_params()
     components = Resie.load_components(components_config, simulation_params)
     electrolyser = components["TST_ELY_01"]
     heat_pump = components["TST_HP_01"]

--- a/test/initialization/profiles.jl
+++ b/test/initialization/profiles.jl
@@ -38,6 +38,12 @@ function test_profile_aggregation_two()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.5
+        end,
+        "wh_to_watts" => function (w)
+            return w * 2.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -74,6 +80,12 @@ function test_profile_aggregation_four()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 1.0
+        end,
+        "wh_to_watts" => function (w)
+            return w * 1.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -106,6 +118,12 @@ function test_profile_segmentation_half()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.125
+        end,
+        "wh_to_watts" => function (w)
+            return w * 8.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -179,6 +197,12 @@ function test_profile_segmentation_third()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.08333333333333
+        end,
+        "wh_to_watts" => function (w)
+            return w * 12.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -295,6 +319,12 @@ function test_profile_segmentation_half_linear()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.125
+        end,
+        "wh_to_watts" => function (w)
+            return w * 8.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)
@@ -368,6 +398,12 @@ function test_profile_segmentation_third_linear()
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.0833333333333
+        end,
+        "wh_to_watts" => function (w)
+            return w * 12.0
+        end,
     )
 
     components = Resie.load_components(components_config, simulation_parameters)

--- a/test/scenarios/cli.jl
+++ b/test/scenarios/cli.jl
@@ -24,6 +24,7 @@ might take a while.
 include("../../src/resie_logger.jl")
 using .Resie_Logger
 using Resie
+using UUIDs
 
 KNOWN_COMMANDS = Set(["generate_output",
                       "set_reference",
@@ -172,6 +173,9 @@ function generate_output(name::String, subdir::String)
         && components !== nothing
         && step_order !== nothing)
         # end of condition
+        run_ID = uuid1()
+        sim_params["run_ID"] = run_ID
+        Resie.current_runs[run_ID] = Resie.SimulationRun(sim_params, components, step_order)
         Resie.run_simulation_loop(project_config, sim_params, components, step_order)
         print("|  ✓  ")
     else

--- a/test/scenarios/cli.jl
+++ b/test/scenarios/cli.jl
@@ -124,7 +124,6 @@ function generate_output(name::String, subdir::String)
     try
         if project_config !== nothing
             sim_params = Resie.get_simulation_params(project_config)
-            Resie.EnergySystems.set_timestep(sim_params["time_step_seconds"])
             print("|  ✓  ")
         else
             print("|     ")

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -87,5 +87,11 @@ function get_default_sim_params()::Dict{String,Any}
         "epsilon" => 1e-9,
         "latitude" => nothing,
         "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.25
+        end,
+        "wh_to_watts" => function (w)
+            return w * 4.0
+        end,
     )
 end

--- a/test/tests_control.jl
+++ b/test/tests_control.jl
@@ -3,6 +3,8 @@ using Test
 using Resie
 using Resie.EnergySystems
 
+include("./test_util.jl")
+
 function setup_control_tests()
     components_config = Dict{String,Any}(
         "TST_GRI_01" => Dict{String,Any}(
@@ -45,11 +47,7 @@ function setup_control_tests()
         ),
     )
 
-    simulation_params = Dict{String,Any}(
-        "time" => 0,
-        "time_step_seconds" => 900,
-        "epsilon" => 1e-9,
-    )
+    simulation_params = get_default_sim_params()
 
     components = Resie.load_components(components_config, simulation_params)
 


### PR DESCRIPTION
* Move helper functions `watt_to_wh` and `wh_to_watts` to simulation parameters. This way they are not dependent on global state
* Add a registry for simulation runs as the only allowed global state in module Resie

Note: This is not yet a full implementation of a simulation server, which is a future feature we will have to implement at some point. This is intended to fix an issue with carrying too much information down the argument-function-call stack/chain and/or having to save a reference to the simulation state in the components.

I am also not terribly happy with how I had to place and define the registry so that it can be used in the submodules within the Resie package. There is a frequent problem with circular imports and definitions that leads to a brittle and idiomatic order in which types are declared and files are imported. However so far I have not found a good solulation to this problem.