### PR TITLE
Improve weather and profile handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ In general the development follows the [semantic versioning](https://semver.org/
 ## Pre-1.0-releases
 As per the definition of semantic versioning and the reality of early development, in versions prior to 1.0.0 any release might break compatability. To alleviate this somewhat, the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some breaking changes may slip beneath notice.
 
+### Version 0.10.6
+* add the possibility to output the weather data from EPW and dat-files to the lineplot and CSV output
+* add two more interpolation methods for segmentation of data: "stepwise", "linear_classic", "linear_time_preserving", "linear_solar_radiation"
+* the time zone can now be specified in the simulation_parameters to overwrite the time zone provided by the weather file
+* change the internal handling of profile time step during segmentation and aggregation from seconds to milliseconds
+* add tests for segmentation algorithms
+
 ### Version 0.10.5
 * restructur import of profiles (constant value, custom profile, from weather file) to a generalised function
 * correct input variable naming for ambient temperature in buffer tank and geothermal collector

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Resie"
 uuid = "2e0f99b1-0d8f-4296-8d0c-1c50a50d04c8"
 authors = ["Maksim Helmann <maksim.helmann@siz-energieplus.de>", "Etienne Ott <etienne.ott@siz-energieplus.de>", "Heiner Steinacker <heiner.steinacker@siz-energieplus.de>", "Adrian Vollmer <adrian.vollmer@siz-energieplus.de>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/profiles/tests/heating_demand_short_linear.prf
+++ b/profiles/tests/heating_demand_short_linear.prf
@@ -3,7 +3,7 @@
 # profile_start_date_format: dd.mm.yyyy HH:MM:SS
 # timestamp_format:          seconds 
 # data_type:                 extensive
-# use_linear_segmentation:   true
+# interpolation_type:        linear_classic
 0;10.0
 900;12.0
 1800;60.0

--- a/profiles/tests/heating_demand_short_linear_time_preserving.prf
+++ b/profiles/tests/heating_demand_short_linear_time_preserving.prf
@@ -2,16 +2,17 @@
 # profile_start_date:        01.01.2024 00:00:00
 # profile_start_date_format: dd.mm.yyyy HH:MM:SS
 # timestamp_format:          seconds 
-# data_type:                 intensive
-# interpolation_type:        linear_classic
-0;65.0
-900;63.0
-1800;70.0
-2700;68.0
-3600;72.0
-4500;72.0
-5400;56.0
-6300;61.0
-7200;66.0
-8100;70.0
+# data_type:                 extensive
+# interpolation_type:        linear_time_preserving
+0;10.0
+900;12.0
+1800;60.0
+2700;0.0
+3600;2.5
+4500;23.0
+5400;5.0
+6300;11.0
+7200;1.0
+8100;42.0
+
 

--- a/profiles/tests/temperature_short_linear_time_preserving.prf
+++ b/profiles/tests/temperature_short_linear_time_preserving.prf
@@ -3,7 +3,7 @@
 # profile_start_date_format: dd.mm.yyyy HH:MM:SS
 # timestamp_format:          seconds 
 # data_type:                 intensive
-# interpolation_type:        linear_classic
+# interpolation_type:        linear_time_preserving
 0;65.0
 900;63.0
 1800;70.0

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -92,6 +92,7 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
         "epsilon" => 1e-9,
         "latitude" => default(project_config["simulation_parameters"], "latitude", nothing),
         "longitude" => default(project_config["simulation_parameters"], "longitude", nothing),
+        "timezone" => default(project_config["simulation_parameters"], "time_zone", nothing),
     )
 
     # add helper functions to convert power to work and vice-versa. this uses the time step

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -111,16 +111,8 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
         weather_interpolation_type = default(project_config["io_settings"],
                                              "weather_interpolation_type",
                                              "stepwise")
-        sim_params["weather_data"], lat, long = WeatherData(weather_file_path, sim_params, weather_interpolation_type)
-
-        if sim_params["latitude"] === nothing || sim_params["longitude"] === nothing
-            sim_params["latitude"] = lat
-            sim_params["longitude"] = long
-        else
-            @info "The coordinates given in the weather file where overwritten by the " *
-                  "ones given in the input file:\n" *
-                  "Latidude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
-        end
+        # WeatherData() writes the lat and long to sim_params if they are not given in the input file
+        sim_params["weather_data"] = WeatherData(weather_file_path, sim_params, weather_interpolation_type)
     end
 
     return sim_params

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -108,10 +108,10 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
                                 nothing)
 
     if weather_file_path !== nothing
-        use_linear_segmentation = default(project_config["io_settings"],
-                                          "use_linear_weather_interpolation",
-                                          false)
-        sim_params["weather_data"], lat, long = WeatherData(weather_file_path, sim_params, use_linear_segmentation)
+        weather_interpolation_type = default(project_config["io_settings"],
+                                             "weather_interpolation_type",
+                                             "stepwise")
+        sim_params["weather_data"], lat, long = WeatherData(weather_file_path, sim_params, weather_interpolation_type)
 
         if sim_params["latitude"] === nothing || sim_params["longitude"] === nothing
             sim_params["latitude"] = lat

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -108,9 +108,9 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
                                 nothing)
 
     if weather_file_path !== nothing
-        weather_interpolation_type = default(project_config["io_settings"],
+        weather_interpolation_type = default(project_config["simulation_parameters"],
                                              "weather_interpolation_type",
-                                             "stepwise")
+                                             "stepwise:linear_time_preserving")
         # WeatherData() writes the lat and long to sim_params if they are not given in the input file
         sim_params["weather_data"] = WeatherData(weather_file_path, sim_params, weather_interpolation_type)
     end

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -108,11 +108,15 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
                                 nothing)
 
     if weather_file_path !== nothing
-        weather_interpolation_type = default(project_config["simulation_parameters"],
-                                             "weather_interpolation_type",
-                                             "stepwise:linear_time_preserving")
+        weather_interpolation_type_solar = default(project_config["simulation_parameters"],
+                                                   "weather_interpolation_type_solar", "linear_solar_radiation")
+        weather_interpolation_type_general = default(project_config["simulation_parameters"],
+                                                     "weather_interpolation_type_general", "linear_classic")
         # WeatherData() writes the lat and long to sim_params if they are not given in the input file
-        sim_params["weather_data"] = WeatherData(weather_file_path, sim_params, weather_interpolation_type)
+        sim_params["weather_data"] = WeatherData(weather_file_path,
+                                                 sim_params,
+                                                 weather_interpolation_type_solar,
+                                                 weather_interpolation_type_general)
     end
 
     return sim_params

--- a/src/Resie.jl
+++ b/src/Resie.jl
@@ -108,7 +108,10 @@ function get_simulation_params(project_config::Dict{AbstractString,Any})::Dict{S
                                 nothing)
 
     if weather_file_path !== nothing
-        sim_params["weather_data"], lat, long = WeatherData(weather_file_path, sim_params)
+        use_linear_segmentation = default(project_config["io_settings"],
+                                          "use_linear_weather_interpolation",
+                                          false)
+        sim_params["weather_data"], lat, long = WeatherData(weather_file_path, sim_params, use_linear_segmentation)
 
         if sim_params["latitude"] === nothing || sim_params["longitude"] === nothing
             sim_params["latitude"] = lat

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -823,12 +823,12 @@ algorithm of TRNSYS 18, described in:
     "A New Method for Determining Sub-hourly Solar Radiation from Hourly Data" 
 
 Parameters:
-  • Hn       : hourly integrated irradiation for the current hour [Wh/m²]
-  • Hnp1     : hourly integrated irradiation for the next hour [Wh/m²]
+  • hn       : hourly integrated irradiation for the current hour [Wh/m²]
+  • hnp1     : hourly integrated irradiation for the next hour [Wh/m²]
   • interval_start, interval_end : start and end of the current hourly interval
       (in fractional hours, e.g., 7.24 or 8.0)
   • dt_h     : required simulation timestep (in hours)
-  • G_start  : carry-over instantaneous radiation from the previous interval (W/m²)
+  • g_start  : carry-over instantaneous radiation from the previous interval (W/m²)
   • sunrise, sunset : daylight bounds (fractional hours)
 
 Returns (t_sub, irr_sub, G_end) where:
@@ -836,85 +836,78 @@ Returns (t_sub, irr_sub, G_end) where:
   • irr_sub is the average irradiance (W/m²) for each subinterval,
   • G_end is the endpoint to carry over.
 """
-function segment_interval(Hn::Float64, Hnp1::Float64,
+function segment_interval(hn::Float64, hnp1::Float64,
                           interval_start::Float64, interval_end::Float64,
-                          dt_h::Float64, G_start::Float64,
+                          dt_h::Float64, g_start::Float64,
                           sunrise::Float64, sunset::Float64)
     # 1. Divide the full hourly interval into dt blocks (using ceil to ensure full coverage)
-    N_total = max(Int(ceil((interval_end - interval_start) / dt_h)), 1)
-    t_blocks = [interval_start + (j - 1) * dt_h for j in 1:N_total]
+    n_total = max(Int(ceil((interval_end - interval_start) / dt_h)), 1)
+    t_blocks = [interval_start + (j - 1) * dt_h for j in 1:n_total]
 
     # 2. Define the effective daylight region.
     eff_start = max(interval_start, sunrise)
     eff_end = min(interval_end, sunset)
     if eff_end <= eff_start
         # No daylight: all dt blocks get zero irradiance.
-        return t_blocks, zeros(Float64, N_total), 0.0
+        return t_blocks, zeros(Float64, n_total), 0.0
     end
     dt_eff = eff_end - eff_start
     is_sunrise = eff_start == sunrise
     is_sunset = eff_end == sunset
 
     # 3. Subdivide the effective region into dt blocks (again using ceil)
-    N_eff = max(Int(ceil(dt_eff / dt_h)), 1)
+    n_eff = max(Int(ceil(dt_eff / dt_h)), 1)
 
     # 4. Compute the effective endpoint.
     # If the hour includes sunset, force the endpoint to zero.
     if (sunset > interval_start && sunset < interval_end)
         effective_G_end = 0.0
     else
-        if Hnp1 > Hn && is_sunrise
-            effective_G_end = (2 * Hn) / dt_eff
-        elseif Hnp1 < Hn && is_sunset
-            effective_G_end = (0.25 * Hn + 0.75 * Hnp1) / dt_eff
+        if hnp1 > hn && is_sunrise
+            effective_G_end = (2 * hn) / dt_eff
+        elseif hnp1 < hn && is_sunset
+            effective_G_end = (0.25 * hn + 0.75 * hnp1) / dt_eff
         else
-            effective_G_end = (0.5 * Hn + 0.5 * Hnp1) / dt_eff
+            effective_G_end = (0.5 * hn + 0.5 * hnp1) / dt_eff
         end
     end
 
-    # 5. Compute the midpoint value (G_mid) over the effective region.
-    g_mid_is_zero = false
-    g_mid_is_still_zero = false
+    # 5. Compute the midpoint value (g_mid) over the effective region.
+    g_mid_was_zero = false
 
-    if N_eff == 1
-        G_mid = Hn / dt_h
+    if n_eff == 1
+        g_mid = hn / dt_h
     else
-        N_mid = Int(floor(N_eff / 2))
-        G_mid = (2 * Hn / (N_eff * dt_h)) - (N_mid * G_start) / N_eff - ((N_eff - N_mid) * effective_G_end) / N_eff
-        if G_mid < 0
-            G_mid = (2 * Hn / dt_h - (G_start + effective_G_end)) / (2 * (N_eff - 1))
-            g_mid_is_zero = true
-        end
-        if G_mid < 0
-            G_mid = 0
-            g_mid_is_still_zero = true
-            g_mid_is_zero = false
+        n_mid = Int(floor(n_eff / 2))
+        g_mid = (2 * hn / (n_eff * dt_h)) - (n_mid * g_start) / n_eff - ((n_eff - n_mid) * effective_G_end) / n_eff
+        if g_mid < 0
+            g_mid = (2 * hn / dt_h - (g_start + effective_G_end)) / (2 * (n_eff - 1))
+            g_mid_was_zero = true
         end
     end
 
     # 6. Build the piecewise–linear boundaries over the effective region.
-    if g_mid_is_zero
-        boundaries = vcat(G_start, fill(G_mid, N_eff))
+    if g_mid < 0  #g_mid still zero?
+        boundaries = vcat(g_start, zeros(n_eff))
+    elseif g_mid_was_zero
+        boundaries = vcat(vcat(g_start, fill(g_mid, n_eff - 1)), effective_G_end)
     else
-        boundaries = zeros(Float64, N_eff + 1)
-        boundaries[1] = G_start
-        if N_eff > 1
-            N_mid = Int(floor(N_eff / 2))
-            # First part: interpolate from G_start to G_mid over N_mid subintervals.
-            for j in 1:N_mid
-                boundaries[j + 1] = G_start + (j / N_mid) * (G_mid - G_start)
-                if g_mid_is_still_zero # the radiation drops to zero at the end of the second step
-                    break
-                end
+        boundaries = zeros(Float64, n_eff + 1)
+        boundaries[1] = g_start
+        if n_eff > 1
+            n_mid = Int(floor(n_eff / 2))
+            # First part: interpolate from g_start to g_mid over n_mid subintervals.
+            for j in 1:n_mid
+                boundaries[j + 1] = g_start + (j / n_mid) * (g_mid - g_start)
             end
-            # Second part: interpolate from G_mid to effective_G_end over the remaining subintervals.
+            # Second part: interpolate from g_mid to effective_G_end over the remaining subintervals.
             #              effective_G_end is considered to be the first value of the next interval.
-            M = g_mid_is_still_zero ? 0 : N_eff - N_mid
-            for k in 1:M
-                boundaries[N_mid + 1 + k] = G_mid + (k / M) * (effective_G_end - G_mid)
+            m = n_eff - n_mid
+            for k in 1:m
+                boundaries[n_mid + 1 + k] = g_mid + (k / m) * (effective_G_end - g_mid)
             end
         else
-            boundaries[2] = G_mid
+            boundaries[2] = g_mid
         end
     end
 
@@ -923,11 +916,11 @@ function segment_interval(Hn::Float64, Hnp1::Float64,
 
     # 8. fill effective_irr with zeros at the beginning or end, depending if we are during 
     #    sunset or sunrise
-    if N_eff < N_total
+    if n_eff < n_total
         if is_sunrise
-            effective_irr = vcat(zeros(Float64, N_total - N_eff), effective_irr)
+            effective_irr = vcat(zeros(Float64, n_total - n_eff), effective_irr)
         elseif is_sunset
-            effective_irr = vcat(effective_irr, zeros(Float64, N_total - N_eff))
+            effective_irr = vcat(effective_irr, zeros(Float64, n_total - n_eff))
         end
     end
 
@@ -970,15 +963,15 @@ function segment_profile(begin_dt::DateTime,
     end
 
     n_hours = length(hourly_H)  # total number of hourly intervals
-    G_start = 0.0  # carry-over start
+    g_start = 0.0  # carry-over start
 
     # Loop over each hourly interval.
     for i in 1:n_hours
         current_hour_dt = add_ignoring_leap_days(begin_dt, Hour(i - 1))
         current_date = Date(current_hour_dt)
-        # Reset G_start at the beginning of a new day.
+        # Reset g_start at the beginning of a new day.
         if i == 1 || (i > 1 && Date(add_ignoring_leap_days(begin_dt, Hour(i - 2))) != current_date)
-            G_start = 0.0
+            g_start = 0.0
         end
 
         # Compute the boundaries of this hourly interval (in fractional hours).
@@ -993,25 +986,25 @@ function segment_profile(begin_dt::DateTime,
         sunrise, sunset = get_sunset_sunrise(current_date, sim_params["latitude"], sim_params["longitude"], tz)
 
         # Retrieve current and next hourly integrated irradiation.
-        Hn = hourly_H[i]
+        hn = hourly_H[i]
         if i < n_hours
             next_date = Date(add_ignoring_leap_days(begin_dt, Hour(i)))
-            Hnp1 = (next_date == current_date) ? hourly_H[i + 1] : 0.0
+            hnp1 = (next_date == current_date) ? hourly_H[i + 1] : 0.0
         else
-            Hnp1 = 0.0
+            hnp1 = 0.0
         end
 
         # Segment the current hourly interval.
-        t_sub, irr_sub, G_end = segment_interval(Hn, Hnp1,
+        t_sub, irr_sub, G_end = segment_interval(hn, hnp1,
                                                  interval_start, interval_end,
-                                                 dt_h, G_start, sunrise, sunset)
+                                                 dt_h, g_start, sunrise, sunset)
         # Convert each fractional hour (relative to midnight) to DateTime for current_date.
         t_sub_dt = [add_ignoring_leap_days(DateTime(current_date), Millisecond(round(Int, t * 3600000)))
                     for t in t_sub]
 
         append!(times_total, t_sub_dt)
         append!(irr_total, irr_sub)
-        G_start = G_end
+        g_start = G_end
     end
 
     return irr_total, times_total

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -32,7 +32,7 @@ The interpolation type can be one of "stepwise", "linear_classic", "linear_time_
 time step to make the values be measured at the time indicated. After the interpolation to a 
 finer time step, the data is shifted back by 1/2 a time step to meet the required definition 
 of the values representing the following time step. This should be used for time-critical data 
-like solar radiation. But, this method will strengthen peaks and drops in the data more than
+like solar radiation. But, this method will reduce the amplitude of peaks and drops in the data more than
 the classic interpolation.
 - "linear_solar_radiation" interpolation uses a method described in the paper 
      T. McDowell, S. Letellier-Duchesne, M. Kummert (2018):

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -864,7 +864,7 @@ function segment_interval(Hn::Float64, Hnp1::Float64,
 
     # 5. Compute the midpoint value (G_mid) over the effective region.
     if N_eff == 1
-        G_mid = Hn / dt_eff
+        G_mid = Hn / dt_h
     else
         N_mid = Int(floor(N_eff / 2))
         G_mid = (2 * Hn / (N_eff * dt_h)) - (N_mid * G_start) / N_eff - ((N_eff - N_mid) * effective_G_end) / N_eff
@@ -886,7 +886,7 @@ function segment_interval(Hn::Float64, Hnp1::Float64,
             boundaries[j + 1] = G_start + (j / N_mid) * (G_mid - G_start)
         end
         # Second part: interpolate from G_mid to effective_G_end over the remaining subintervals.
-        #              effective_G_end is considered to be the first value of the previous interval.
+        #              effective_G_end is considered to be the first value of the next interval.
         M = N_eff - N_mid
         for k in 1:M
             boundaries[N_mid + 1 + k] = G_mid + (k / M) * (effective_G_end - G_mid)
@@ -907,6 +907,9 @@ function segment_interval(Hn::Float64, Hnp1::Float64,
             effective_irr = vcat(effective_irr, zeros(Float64, N_total - N_eff))
         end
     end
+
+    # 9. Scale irradiation to get energy
+    effective_irr *= dt_h
 
     return t_blocks, effective_irr, effective_G_end
 end

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -80,7 +80,7 @@ mutable struct Profile
                 for (line_idx, line) in enumerate(readlines(file_handle))
                     line = strip(line)
 
-                    if isempty(line) || length(line) < 2 # handle empty lines
+                    if isempty(line) || length(line) < 1 # handle empty lines
                         continue
                     elseif line[1] == '#'
                         splitted = split(strip(line, '#'), ':'; limit=2)

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -34,8 +34,9 @@ finer time step, the data is shifted back by 1/2 a time step to meet the require
 of the values representing the following time step. This should be used for time-critic data 
 like solar radiation. But, this method will cut peaks and valleys in the data more than the 
 classic interpolation.
-- "linear_solar_radiation" interpolation uses a method described in the paper "A new method for
-interpolating hourly solar radiation data" by M. A. S. Mohandes, A. Halawani, and A. Rehman.
+- "linear_solar_radiation" interpolation uses a method described in the paper 
+     T. McDowell, S. Letellier-Duchesne, M. Kummert (2018):
+    "A New Method for Determining Sub-hourly Solar Radiation from Hourly Data" 
 It is a linear interpolation with a correction factor to keep the sum of the interpolated values
 equal to the sum of the original values. This is also used in TRNSYS 18, but shows "wavy" curves
 as result.
@@ -818,8 +819,8 @@ end
     segment_interval() 
 segments one hourly interval given as fractional times (relative to midnight) using the 
 algorithm of TRNSYS 18, described in:
-    Letellier-Duchesne, Samuel & McDowell, Timothy & Kummert, Michael. (2018). 
-    A New Method for Determining Sub-hourly Solar Radiation from Hourly Data. 
+    T. McDowell, S. Letellier-Duchesne, M. Kummert (2018):
+    "A New Method for Determining Sub-hourly Solar Radiation from Hourly Data" 
 
 Parameters:
   • Hn       : hourly integrated irradiation for the current hour [Wh/m²]

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -19,6 +19,10 @@ and the data_type (intensive/extensive) has to be provided as optional arguments
 The data_type is essential to make sure that the profile data is converted correctly.
 It has to be set to "intensive" for values like temperatures, power, wind speed or
 for profiles containting states. Only for energies, data_type has to be set to "extensive".
+
+Data should represent the time step following the time indicated /mean/sum). The shift parameter
+can be used to shift the timestamp to the correct time. A positive shift will add to the timestamp,
+which means the value is later. 
 """
 mutable struct Profile
     """Time step, in seconds, of the profile."""
@@ -41,8 +45,10 @@ mutable struct Profile
                      #                                                            timestep in seconds of the given data
                      given_data_type::Union{String,Nothing}=nothing,  # optional: datatype, shoule be "intensive" or
                      #                                                            "extensive"
-                     shift::Dates.Second=Second(0))                   # optional: timeshift for data. A positive shift 
-        #                                                                         adds to the timestamp = value is earlier
+                     shift::Dates.Second=Second(0),                   # optional: timeshift for data. A positive shift 
+                     #                                                            adds to the timestamp = value is later
+                     use_linear_segmentation::Bool=false)             # optional: flag if a linear (true) or stepwise 
+        #                                                                         interpolation for segmentation should be used
         if given_profile_values == []  # read data from file_path
             profile_values = Vector{Float64}()
             profile_timestamps = Vector{String}()
@@ -211,7 +217,6 @@ mutable struct Profile
             profile_timestamps_date = given_timestamps
             data_type = given_data_type
             time_zone = nothing
-            use_linear_segmentation = true
         end
 
         # remove leap days and daiylight savings from profile

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -982,8 +982,10 @@ function segment_profile(begin_dt::DateTime,
         interval_end = (i == n_hours) ? fractional_hour(end_dt) : end_of_hour
 
         # Get sunrise and sunset for current_date.
-        tz = +1.0  # TODO
-        sunrise, sunset = get_sunset_sunrise(current_date, sim_params["latitude"], sim_params["longitude"], tz)
+        sunrise, sunset = get_sunset_sunrise(current_date,
+                                             sim_params["latitude"],
+                                             sim_params["longitude"],
+                                             sim_params["timezone"])
 
         # Retrieve current and next hourly integrated irradiation.
         hn = hourly_H[i]

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -9,7 +9,7 @@ export Profile, power_at_time, work_at_time, value_at_time, remove_leap_days,
 Holds values from a file so they can be retrieved later and indexed by time.
 
 Profiles are automatically aggregated or segmentated to fit the simulation time step.
-Currtently, this only works, if the time step of the profile is a multiple or a divisor 
+Currently, this only works if the time step of the profile is a multiple or a divisor 
 of the requested simulation timestep. Otherwise, an error will arise.
 
 This function can handle either a path to a .prf file, or the profile data can be
@@ -18,7 +18,7 @@ and the data_type (intensive/extensive) has to be provided as optional arguments
 
 The data_type is essential to make sure that the profile data is converted correctly.
 It has to be set to "intensive" for values like temperatures, power, wind speed or
-for profiles containting states. Only for energies, data_type has to be set to "extensive".
+for profiles containing states. Only for energies the data_type has to be set to "extensive".
 
 Data should represent the time step following the time indicated (mean/sum). The shift parameter
 can be used to shift the timestamp to the correct time. A positive shift will add to the timestamp,
@@ -31,9 +31,9 @@ The interpolation type can be one of "stepwise", "linear_classic", "linear_time_
 - "linear_time_preserving" interpolates the data by first shifting the data by half the original 
 time step to make the values be measured at the time indicated. After the interpolation to a 
 finer time step, the data is shifted back by 1/2 a time step to meet the required definition 
-of the values representing the following time step. This should be used for time-critic data 
-like solar radiation. But, this method will cut peaks and valleys in the data more than the 
-classic interpolation.
+of the values representing the following time step. This should be used for time-critical data 
+like solar radiation. But, this method will strengthen peaks and drops in the data more than
+the classic interpolation.
 - "linear_solar_radiation" interpolation uses a method described in the paper 
      T. McDowell, S. Letellier-Duchesne, M. Kummert (2018):
     "A New Method for Determining Sub-hourly Solar Radiation from Hourly Data" 
@@ -244,7 +244,7 @@ mutable struct Profile
             throw(InputError)
         end
 
-        # remove leap days and daiylight savings from profile
+        # remove leap days and daylight savings from profile
         profile_timestamps_date, profile_values = remove_leap_days(profile_timestamps_date, profile_values, file_path)
         profile_timestamps_date = remove_day_light_saving(profile_timestamps_date, time_zone, file_path)
 
@@ -270,7 +270,7 @@ mutable struct Profile
             profile_timestamps_date = vcat(profile_timestamps_date[1] - Second(profile_time_step),
                                            profile_timestamps_date)
             profile_values = vcat(profile_values[1], profile_values)
-            @info "The profile at $(file_path) has been extended by one timestep at the begin by doubling the fist value."
+            @info "The profile at $(file_path) has been extended by one timestep at the begin by doubling the first value."
         end
         temp_diff = Second(max(profile_time_step, sim_params["time_step_seconds"]))
         time_diff_timesteps = Second(max(0, Int64(sim_params["time_step_seconds"]) - profile_time_step))
@@ -353,7 +353,7 @@ end
 """
     convert_String_to_DateFormat()
 
-function to pase a string to a a DateFormat.
+function to parse a string to a a DateFormat.
     datetime_str::String      A DateFormat as string
     file_path::String         File path of the profile for error handling, for error message.
 
@@ -365,7 +365,7 @@ function convert_String_to_DateFormat(datetime_str::String, file_path::String)::
         return DateFormat(datetime_str)
     catch e
         @error "Time given date specifier '$(datetime_str)' of profile at $(file_path) could not be converted " *
-               "to a DateFormat. Make shure, is matches the format specification of the Julia Dates package. " *
+               "to a DateFormat. Make sure it matches the format specification of the Julia Dates package. " *
                "The following error occured: $e"
         throw(InputError)
     end
@@ -374,9 +374,9 @@ end
 """
     parse_datestamp()
 
-function to pase a datestamp from a string to a given date format.
+function to parse a datestamp from a string to a given date format.
     datetime_str::String        Timestamp read from the profile file. Should be a specified DateTime format as string.
-    time_format::DateFormat     Format of datetime_str. Shoule be a DateTime format, like "dd-mm-yyyy HH:MM:SS"
+    time_format::DateFormat     Format of datetime_str. Should be a DateTime format, like "dd-mm-yyyy HH:MM:SS"
     file_path::String           File path of the profile for error handling, for error message.
     time_format_variable_name::String   The variable name of the time format, for error message.
 
@@ -428,7 +428,7 @@ end
     add_ignoring_leap_days(timestamp::DateTime, diff::DateTime.Period)
 
 Adds diff to the timestamp. If the result is a leap day, skip to the next day.
-If a leap day is in between, do not count it!
+If a leap day is in between, it is not counted!
 """
 function add_ignoring_leap_days(timestamp::DateTime, diff::Period)
     new_time = timestamp + diff
@@ -448,8 +448,8 @@ end
 """
     sub_ignoring_leap_days(timestamp::DateTime, diff::DateTime.Period)
 
-Subs diff of the timestamp. If the result is a leap day, skip to the previous day.
-If a leap day is in between, do not count it!
+Subtracts diff from the timestamp. If the result is a leap day, skip to the previous day.
+If a leap day is in between, it is not counted!
 """
 function sub_ignoring_leap_days(timestamp::DateTime, diff::Period)
     new_time = timestamp - diff
@@ -469,9 +469,9 @@ end
 """
     sub_ignoring_leap_days(end_date::DateTime, begin_date::DateTime)
 
-Substract: DateTime.Period = end_date - begin_date
-If the result is a leap day, skip to the next day.
-If a leap day is in between, do not count it!
+Subtract: DateTime.Period = end_date - begin_date
+If the result is a leap day, skips to the next day.
+If a leap day is in between, it is not counted!
 """
 function sub_ignoring_leap_days(end_date::DateTime, begin_date::DateTime)
     time_span = end_date - begin_date
@@ -516,7 +516,7 @@ end
 """
     remove_day_light_saving(timestamp::Vector{DateTime}, time_zone::Stringing, file_path::String)
 
-If DST is present in the timestamp, shift it to local standard time.
+If DST is present in the timestamp, shifts it to local standard time.
 
 This may require a recompilation of the TZData of the Julia package TimeZones. From first installation,
 if only covers DST shifts until the year 2037. 

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -16,7 +16,7 @@ This function can handle either a path to a .prf file, or the profile data can b
 handed over as vectors. Then, the profile with the corresponding timestamps, the time step
 and the data_type (intensive/extensive) has to be provided as optional arguments. 
 
-The data_type is essential to make sure that the profile data is converted correcty.
+The data_type is essential to make sure that the profile data is converted correctly.
 It has to be set to "intensive" for values like temperatures, power, wind speed or
 for profiles containting states. Only for energies, data_type has to be set to "extensive".
 """

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -77,6 +77,14 @@ mutable struct WeatherData
                       "ones given in the input file:\n" *
                       "Latidude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
             end
+            if sim_params["timezone"] === nothing
+                sim_params["timezone"] = 1.0  # MEZ
+                @info "The timezone was set to MEZ (GMT+1) as it is the standard for DWD .dat files."
+            else
+                sim_params["timezone"] = Float64(sim_params["timezone"])
+                @info "The timezone given in the DWD .dat file was overwritten by the " *
+                      "one given in the input file: $(sim_params["timezone"])"
+            end
 
             # Attention! The radiation data in the DWD-dat file is given as power in [W/m2]. To be 
             #            consistent with the data from EWP, it is treated as energy in [Wh/m2] here!
@@ -145,6 +153,13 @@ mutable struct WeatherData
                 @info "The coordinates given in the weather file where overwritten by the " *
                       "ones given in the input file:\n" *
                       "Latidude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
+            end
+            if sim_params["timezone"] === nothing
+                sim_params["timezone"] = Float64(headerdata["TZ"])
+            else
+                sim_params["timezone"] = Float64(sim_params["timezone"])
+                @info "The timezone given in the EPW weather file was overwritten by the " *
+                      "one given in the input file: $(sim_params["timezone"])"
             end
 
             # convert solar radiation data to profile

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -75,7 +75,7 @@ mutable struct WeatherData
             else
                 @info "The coordinates given in the weather file where overwritten by the " *
                       "ones given in the input file:\n" *
-                      "Latidude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
+                      "Latitude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
             end
             if sim_params["timezone"] === nothing
                 sim_params["timezone"] = 1.0  # MEZ
@@ -152,7 +152,7 @@ mutable struct WeatherData
             else
                 @info "The coordinates given in the weather file where overwritten by the " *
                       "ones given in the input file:\n" *
-                      "Latidude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
+                      "Latitude: $(sim_params["latitude"]); Longitude: $(sim_params["longitude"])"
             end
             if sim_params["timezone"] === nothing
                 sim_params["timezone"] = Float64(headerdata["TZ"])
@@ -184,7 +184,7 @@ mutable struct WeatherData
             globHorIrr = deepcopy(dirHorIrr)
             globHorIrr.data = Dict(key => dirHorIrr.data[key] + difHorIrr.data[key] for key in keys(dirHorIrr.data))
 
-            # Long wave irradiation is probabely(?) given at full hours
+            # Long wave irradiation is probably(?) given at full hours
             longWaveIrr = Profile(weather_file_path * ":LongWaveIrradiation",
                                   sim_params;
                                   given_profile_values=repeat(Float64.(weatherdata_dict["longWaveIrr"]), nr_of_years),

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -146,14 +146,14 @@ mutable struct WeatherData
 
             # convert solar radiation data to profile
             # Radiation data in EPW is given as sum over the preceding time step. The first time step is mapped to 00:00.
-            globHorIrr = Profile(weather_file_path * ":GlobalHorizontalIrradiation",
-                                 sim_params;
-                                 given_profile_values=repeat(Float64.(weatherdata_dict["ghi"]), nr_of_years),
-                                 given_timestamps=timestamp,
-                                 given_time_step=time_step,
-                                 given_data_type="extensive",
-                                 shift=Second(0),
-                                 interpolation_type="linear_solar_radiation")
+            # globHorIrr = Profile(weather_file_path * ":GlobalHorizontalIrradiation",
+            #                      sim_params;
+            #                      given_profile_values=repeat(Float64.(weatherdata_dict["ghi"]), nr_of_years),
+            #                      given_timestamps=timestamp,
+            #                      given_time_step=time_step,
+            #                      given_data_type="extensive",
+            #                      shift=Second(0),
+            #                      interpolation_type="linear_solar_radiation")
             difHorIrr = Profile(weather_file_path * ":DiffuseHorizontalIrradiation",
                                 sim_params;
                                 given_profile_values=repeat(Float64.(weatherdata_dict["dhi"]), nr_of_years),
@@ -162,8 +162,17 @@ mutable struct WeatherData
                                 given_data_type="extensive",
                                 shift=Second(0),
                                 interpolation_type="linear_solar_radiation")
-            dirHorIrr = deepcopy(globHorIrr)
-            dirHorIrr.data = Dict(key => dirHorIrr.data[key] - difHorIrr.data[key] for key in keys(dirHorIrr.data))
+            dirHorIrr = Profile(weather_file_path * ":DirHorizontalIrradiation",
+                                sim_params;
+                                given_profile_values=repeat(Float64.(weatherdata_dict["ghi"] .- weatherdata_dict["dhi"]),
+                                                            nr_of_years),
+                                given_timestamps=timestamp,
+                                given_time_step=time_step,
+                                given_data_type="extensive",
+                                shift=Second(0),
+                                interpolation_type="linear_solar_radiation")
+            globHorIrr = deepcopy(dirHorIrr)
+            globHorIrr.data = Dict(key => dirHorIrr.data[key] + difHorIrr.data[key] for key in keys(dirHorIrr.data))
 
             # Long wave irradiation is probabely(?) given at full hours
             longWaveIrr = Profile(weather_file_path * ":LongWaveIrradiation",

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -43,7 +43,7 @@ mutable struct WeatherData
     accordingly.
 
     """
-    function WeatherData(weather_file_path::String, sim_params::Dict{String,Any})
+    function WeatherData(weather_file_path::String, sim_params::Dict{String,Any}, use_linear_segmentation::Bool)
         if !isfile(weather_file_path)
             @error "The weather file could not be found in: \n $weather_file_path"
             throw(InputError)
@@ -72,14 +72,16 @@ mutable struct WeatherData
                                 given_timestamps=timestamp,
                                 given_time_step=time_step,
                                 given_data_type="extensive",
-                                shift=Second(0))
+                                shift=Second(0),
+                                use_linear_segmentation=use_linear_segmentation)
             difHorIrr = Profile(weather_file_path * ":DiffuseHorizontalIrradiation",
                                 sim_params;
                                 given_profile_values=repeat(Float64.(weatherdata_dict["difHorIrr"]), nr_of_years),
                                 given_timestamps=timestamp,
                                 given_time_step=time_step,
                                 given_data_type="extensive",
-                                shift=Second(0))
+                                shift=Second(0),
+                                use_linear_segmentation=use_linear_segmentation)
             globHorIrr = deepcopy(dirHorIrr)
             globHorIrr.data = Dict(key => globHorIrr.data[key] + difHorIrr.data[key] for key in keys(globHorIrr.data))
 
@@ -90,7 +92,8 @@ mutable struct WeatherData
                                  given_timestamps=timestamp,
                                  given_time_step=time_step,
                                  given_data_type="intensive",
-                                 shift=Second(25 * 60))
+                                 shift=Second(25 * 60),
+                                 use_linear_segmentation=use_linear_segmentation)
 
             # Values measured at full hours
             longWaveIrr = Profile(weather_file_path * ":LongWaveIrradiation",
@@ -99,7 +102,8 @@ mutable struct WeatherData
                                   given_timestamps=timestamp,
                                   given_time_step=time_step,
                                   given_data_type="extensive",
-                                  shift=Second(30 * 60))
+                                  shift=Second(30 * 60),
+                                  use_linear_segmentation=use_linear_segmentation)
 
             # Temperatures are measured half an hour bevor the timestep indicated (hour 1 => 00:00).
             temp_ambient_air = Profile(weather_file_path * ":AmbientTemperature",
@@ -108,7 +112,8 @@ mutable struct WeatherData
                                        given_timestamps=timestamp,
                                        given_time_step=time_step,
                                        given_data_type="intensive",
-                                       shift=Second(0))
+                                       shift=Second(0),
+                                       use_linear_segmentation=use_linear_segmentation)
 
             # calculate latitude and longitude from Hochwert and Rechtswert from header
             inProj = "EPSG:3034"   # Input Projection: EPSG system used by DWD for TRY data (Lambert-konforme konische Projektion)
@@ -127,14 +132,16 @@ mutable struct WeatherData
                                  given_timestamps=timestamp,
                                  given_time_step=time_step,
                                  given_data_type="extensive",
-                                 shift=Second(0))
+                                 shift=Second(0),
+                                 use_linear_segmentation=use_linear_segmentation)
             difHorIrr = Profile(weather_file_path * ":DiffuseHorizontalIrradiation",
                                 sim_params;
                                 given_profile_values=repeat(Float64.(weatherdata_dict["dhi"]), nr_of_years),
                                 given_timestamps=timestamp,
                                 given_time_step=time_step,
                                 given_data_type="extensive",
-                                shift=Second(0))
+                                shift=Second(0),
+                                use_linear_segmentation=use_linear_segmentation)
             dirHorIrr = deepcopy(globHorIrr)
             dirHorIrr.data = Dict(key => dirHorIrr.data[key] - difHorIrr.data[key] for key in keys(dirHorIrr.data))
 
@@ -145,7 +152,8 @@ mutable struct WeatherData
                                   given_timestamps=timestamp,
                                   given_time_step=time_step,
                                   given_data_type="extensive",
-                                  shift=Second(30 * 60))
+                                  shift=Second(30 * 60),
+                                  use_linear_segmentation=use_linear_segmentation)
 
             # Temperature is given as value at the time indicated. (Hour1 = 00:00)
             temp_ambient_air = Profile(weather_file_path * ":AmbientTemperature",
@@ -154,7 +162,8 @@ mutable struct WeatherData
                                        given_timestamps=timestamp,
                                        given_time_step=time_step,
                                        given_data_type="intensive",
-                                       shift=Second(30 * 60))
+                                       shift=Second(30 * 60),
+                                       use_linear_segmentation=use_linear_segmentation)
 
             # Wind speed is given as value at the time indicated. (Hour1 = 00:00)
             wind_speed = Profile(weather_file_path * ":WindSpeed",
@@ -163,7 +172,8 @@ mutable struct WeatherData
                                  given_timestamps=timestamp,
                                  given_time_step=time_step,
                                  given_data_type="intensive",
-                                 shift=Second(30 * 60))
+                                 shift=Second(30 * 60),
+                                 use_linear_segmentation=use_linear_segmentation)
 
             latitude = headerdata["latitude"]
             longitude = headerdata["longitude"]

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -43,7 +43,7 @@ mutable struct WeatherData
     accordingly.
 
     """
-    function WeatherData(weather_file_path::String, sim_params::Dict{String,Any}, use_linear_segmentation::Bool)
+    function WeatherData(weather_file_path::String, sim_params::Dict{String,Any}, weather_interpolation_type::String)
         if !isfile(weather_file_path)
             @error "The weather file could not be found in: \n $weather_file_path"
             throw(InputError)
@@ -73,7 +73,7 @@ mutable struct WeatherData
                                 given_time_step=time_step,
                                 given_data_type="extensive",
                                 shift=Second(0),
-                                use_linear_segmentation=use_linear_segmentation)
+                                interpolation_type=weather_interpolation_type)
             difHorIrr = Profile(weather_file_path * ":DiffuseHorizontalIrradiation",
                                 sim_params;
                                 given_profile_values=repeat(Float64.(weatherdata_dict["difHorIrr"]), nr_of_years),
@@ -81,7 +81,7 @@ mutable struct WeatherData
                                 given_time_step=time_step,
                                 given_data_type="extensive",
                                 shift=Second(0),
-                                use_linear_segmentation=use_linear_segmentation)
+                                interpolation_type=weather_interpolation_type)
             globHorIrr = deepcopy(dirHorIrr)
             globHorIrr.data = Dict(key => globHorIrr.data[key] + difHorIrr.data[key] for key in keys(globHorIrr.data))
 
@@ -93,7 +93,7 @@ mutable struct WeatherData
                                  given_time_step=time_step,
                                  given_data_type="intensive",
                                  shift=Second(25 * 60),
-                                 use_linear_segmentation=use_linear_segmentation)
+                                 interpolation_type=weather_interpolation_type)
 
             # Values measured at full hours
             longWaveIrr = Profile(weather_file_path * ":LongWaveIrradiation",
@@ -103,7 +103,7 @@ mutable struct WeatherData
                                   given_time_step=time_step,
                                   given_data_type="extensive",
                                   shift=Second(30 * 60),
-                                  use_linear_segmentation=use_linear_segmentation)
+                                  interpolation_type=weather_interpolation_type)
 
             # Temperatures are measured half an hour bevor the timestep indicated (hour 1 => 00:00).
             temp_ambient_air = Profile(weather_file_path * ":AmbientTemperature",
@@ -113,7 +113,7 @@ mutable struct WeatherData
                                        given_time_step=time_step,
                                        given_data_type="intensive",
                                        shift=Second(0),
-                                       use_linear_segmentation=use_linear_segmentation)
+                                       interpolation_type=weather_interpolation_type)
 
             # calculate latitude and longitude from Hochwert and Rechtswert from header
             inProj = "EPSG:3034"   # Input Projection: EPSG system used by DWD for TRY data (Lambert-konforme konische Projektion)
@@ -133,7 +133,7 @@ mutable struct WeatherData
                                  given_time_step=time_step,
                                  given_data_type="extensive",
                                  shift=Second(0),
-                                 use_linear_segmentation=use_linear_segmentation)
+                                 interpolation_type=weather_interpolation_type)
             difHorIrr = Profile(weather_file_path * ":DiffuseHorizontalIrradiation",
                                 sim_params;
                                 given_profile_values=repeat(Float64.(weatherdata_dict["dhi"]), nr_of_years),
@@ -141,7 +141,7 @@ mutable struct WeatherData
                                 given_time_step=time_step,
                                 given_data_type="extensive",
                                 shift=Second(0),
-                                use_linear_segmentation=use_linear_segmentation)
+                                interpolation_type=weather_interpolation_type)
             dirHorIrr = deepcopy(globHorIrr)
             dirHorIrr.data = Dict(key => dirHorIrr.data[key] - difHorIrr.data[key] for key in keys(dirHorIrr.data))
 
@@ -153,7 +153,7 @@ mutable struct WeatherData
                                   given_time_step=time_step,
                                   given_data_type="extensive",
                                   shift=Second(30 * 60),
-                                  use_linear_segmentation=use_linear_segmentation)
+                                  interpolation_type=weather_interpolation_type)
 
             # Temperature is given as value at the time indicated. (Hour1 = 00:00)
             temp_ambient_air = Profile(weather_file_path * ":AmbientTemperature",
@@ -163,7 +163,7 @@ mutable struct WeatherData
                                        given_time_step=time_step,
                                        given_data_type="intensive",
                                        shift=Second(30 * 60),
-                                       use_linear_segmentation=use_linear_segmentation)
+                                       interpolation_type=weather_interpolation_type)
 
             # Wind speed is given as value at the time indicated. (Hour1 = 00:00)
             wind_speed = Profile(weather_file_path * ":WindSpeed",
@@ -173,7 +173,7 @@ mutable struct WeatherData
                                  given_time_step=time_step,
                                  given_data_type="intensive",
                                  shift=Second(30 * 60),
-                                 use_linear_segmentation=use_linear_segmentation)
+                                 interpolation_type=weather_interpolation_type)
 
             latitude = headerdata["latitude"]
             longitude = headerdata["longitude"]

--- a/src/profiles/weatherdata.jl
+++ b/src/profiles/weatherdata.jl
@@ -4,7 +4,7 @@ using Resie.Profiles
 using Dates
 using Proj
 
-export WeatherData
+export WeatherData, gather_weather_data, get_weather_data_keys
 
 """
 """
@@ -359,6 +359,25 @@ function read_epw_file(weather_file_path::String)
     @info "The EPW weather dataset from '$(headerdata["city"])' with $(expected_length) data points was successfully read."
 
     return weatherdata_dict, headerdata
+end
+
+function get_weather_data_keys(sim_params::Dict{String,Any})
+    if haskey(sim_params, "weather_data")
+        return collect(String.(fieldnames(typeof(sim_params["weather_data"]))))
+    else
+        return nothing
+    end
+end
+
+function gather_weather_data(weather_data_keys, sim_params)
+    return_values = Vector{Any}()
+    append!(return_values, sim_params["time"])
+
+    for weather_data_key in weather_data_keys
+        append!(return_values,
+                Profiles.value_at_time(getfield(sim_params["weather_data"], Symbol(weather_data_key)), sim_params))
+    end
+    return return_values
 end
 
 end

--- a/test/initialization/profiles.jl
+++ b/test/initialization/profiles.jl
@@ -287,7 +287,7 @@ end
     test_profile_segmentation_third()
 end
 
-function energy_system()::Dict{String,Any}
+function energy_system_linear_classic()::Dict{String,Any}
     return Dict{String,Any}(
         "TST_GRI_01" => Dict{String,Any}(
             "type" => "GridConnection",
@@ -306,8 +306,8 @@ function energy_system()::Dict{String,Any}
     )
 end
 
-function test_profile_segmentation_half_linear()
-    components_config = energy_system()
+function test_profile_segmentation_half_linear_classic()
+    components_config = energy_system_linear_classic()
 
     simulation_parameters = Dict{String,Any}(
         "time" => 0,
@@ -385,8 +385,8 @@ function test_profile_segmentation_half_linear()
               simulation_parameters["epsilon"]) == true
 end
 
-function test_profile_segmentation_third_linear()
-    components_config = energy_system()
+function test_profile_segmentation_third_linear_classic()
+    components_config = energy_system_linear_classic()
 
     simulation_parameters = Dict{String,Any}(
         "time" => 0,
@@ -481,7 +481,206 @@ function test_profile_segmentation_third_linear()
               simulation_parameters["epsilon"]) == true
 end
 
-@testset "profiles_linear" begin
-    test_profile_segmentation_half_linear()
-    test_profile_segmentation_third_linear()
+@testset "profiles_linear_classic" begin
+    test_profile_segmentation_half_linear_classic()
+    test_profile_segmentation_third_linear_classic()
+end
+
+function energy_system_linear_time_preserving()::Dict{String,Any}
+    return Dict{String,Any}(
+        "TST_GRI_01" => Dict{String,Any}(
+            "type" => "GridConnection",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => ["TST_DEM_01"],
+            "is_source" => true,
+        ),
+        "TST_DEM_01" => Dict{String,Any}(
+            "type" => "Demand",
+            "medium" => "m_h_w_ht1",
+            "output_refs" => [],
+            "energy_profile_file_path" => "./profiles/tests/heating_demand_short_linear_time_preserving.prf",
+            "temperature_profile_file_path" => "./profiles/tests/temperature_short_linear_time_preserving.prf",
+            "scale" => 1,
+        ),
+    )
+end
+
+function test_profile_segmentation_half_linear_time_preserving()
+    components_config = energy_system_linear_time_preserving()
+
+    simulation_parameters = Dict{String,Any}(
+        "time" => 0,
+        "current_date" => DateTime("01.01.2024 00:00", "dd.mm.yyy HH:MM"),
+        "time_step_seconds" => 450,
+        "number_of_time_steps" => 18,
+        "start_date" => DateTime("01.01.2024 00:00", "dd.mm.yyy HH:MM"),
+        "end_date" => DateTime("01.01.2024 02:15", "dd.mm.yyy HH:MM"),
+        "epsilon" => 1e-9,
+        "latitude" => nothing,
+        "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.125
+        end,
+        "wh_to_watts" => function (w)
+            return w * 8.0
+        end,
+    )
+
+    components = Resie.load_components(components_config, simulation_parameters)
+    demand = components["TST_DEM_01"]
+
+    @test demand.energy_profile.time_step == 450
+    @test demand.energy_profile.data_type == :extensive
+    expected = Dict(DateTime("2024-01-01T00:00:00") => 5.0,
+                    DateTime("2024-01-01T00:07:30") => 5.25,
+                    DateTime("2024-01-01T00:15:00") => 5.75,
+                    DateTime("2024-01-01T00:22:30") => 12.0,
+                    DateTime("2024-01-01T00:30:00") => 24.0,
+                    DateTime("2024-01-01T00:37:30") => 22.5,
+                    DateTime("2024-01-01T00:45:00") => 7.5,
+                    DateTime("2024-01-01T00:52:30") => 0.3125,
+                    DateTime("2024-01-01T01:00:00") => 0.9375,
+                    DateTime("2024-01-01T01:07:30") => 3.8125,
+                    DateTime("2024-01-01T01:15:00") => 8.9375,
+                    DateTime("2024-01-01T01:22:30") => 9.25,
+                    DateTime("2024-01-01T01:30:00") => 4.75,
+                    DateTime("2024-01-01T01:37:30") => 3.25,
+                    DateTime("2024-01-01T01:45:00") => 4.75,
+                    DateTime("2024-01-01T01:52:30") => 4.25,
+                    DateTime("2024-01-01T02:00:00") => 1.75,
+                    DateTime("2024-01-01T02:07:30") => 5.625,
+                    DateTime("2024-01-01T02:15:00") => 10.75)
+    @test all([demand.energy_profile.data[k] - expected[k] for k in keys(expected)] .<
+              simulation_parameters["epsilon"]) == true
+    @test all([demand.energy_profile.data[k] - expected[k] for k in keys(demand.energy_profile.data)] .<
+              simulation_parameters["epsilon"]) == true
+
+    @test sum(values(demand.energy_profile.data)) == 140.375
+
+    @test demand.temperature_profile.time_step == 450
+    @test demand.temperature_profile.data_type == :intensive
+    expected = Dict(DateTime("2024-01-01T00:00:00") => 65.0,
+                    DateTime("2024-01-01T00:07:30") => 64.5,
+                    DateTime("2024-01-01T00:15:00") => 63.5,
+                    DateTime("2024-01-01T00:22:30") => 64.75,
+                    DateTime("2024-01-01T00:30:00") => 68.25,
+                    DateTime("2024-01-01T00:37:30") => 69.5,
+                    DateTime("2024-01-01T00:45:00") => 68.5,
+                    DateTime("2024-01-01T00:52:30") => 69.0,
+                    DateTime("2024-01-01T01:00:00") => 71.0,
+                    DateTime("2024-01-01T01:07:30") => 72.0,
+                    DateTime("2024-01-01T01:15:00") => 72.0,
+                    DateTime("2024-01-01T01:22:30") => 68.0,
+                    DateTime("2024-01-01T01:30:00") => 60.0,
+                    DateTime("2024-01-01T01:37:30") => 57.25,
+                    DateTime("2024-01-01T01:45:00") => 59.75,
+                    DateTime("2024-01-01T01:52:30") => 62.25,
+                    DateTime("2024-01-01T02:00:00") => 64.75,
+                    DateTime("2024-01-01T02:07:30") => 67.0,
+                    DateTime("2024-01-01T02:15:00") => 68.0)
+    @test all([demand.temperature_profile.data[k] - expected[k] for k in keys(expected)] .<
+              simulation_parameters["epsilon"]) == true
+    @test all([demand.temperature_profile.data[k] - expected[k] for k in keys(demand.temperature_profile.data)] .<
+              simulation_parameters["epsilon"]) == true
+end
+
+function test_profile_segmentation_third_linear_time_preserving()
+    components_config = energy_system_linear_time_preserving()
+
+    simulation_parameters = Dict{String,Any}(
+        "time" => 0,
+        "current_date" => DateTime("01.01.2024 00:00", "dd.mm.yyy HH:MM"),
+        "time_step_seconds" => 300,
+        "number_of_time_steps" => 27,
+        "start_date" => DateTime("01.01.2024 00:00", "dd.mm.yyy HH:MM"),
+        "end_date" => DateTime("01.01.2024 02:15", "dd.mm.yyy HH:MM"),
+        "epsilon" => 1e-9,
+        "latitude" => nothing,
+        "longitude" => nothing,
+        "watt_to_wh" => function (w)
+            return w * 0.0833333333333
+        end,
+        "wh_to_watts" => function (w)
+            return w * 12.0
+        end,
+    )
+
+    components = Resie.load_components(components_config, simulation_parameters)
+    demand = components["TST_DEM_01"]
+
+    @test demand.energy_profile.time_step == 300
+    @test demand.energy_profile.data_type == :extensive
+    expected = Dict(DateTime("2024-01-01T00:00:00") => 3.333333333333333,
+                    DateTime("2024-01-01T00:05:00") => 3.333333333333333,
+                    DateTime("2024-01-01T00:10:00") => 3.5555555555555554,
+                    DateTime("2024-01-01T00:15:00") => 3.7777777777777777,
+                    DateTime("2024-01-01T00:20:00") => 4.0,
+                    DateTime("2024-01-01T00:25:00") => 9.333333333333332,
+                    DateTime("2024-01-01T00:30:00") => 14.666666666666666,
+                    DateTime("2024-01-01T00:35:00") => 20.0,
+                    DateTime("2024-01-01T00:40:00") => 13.333333333333332,
+                    DateTime("2024-01-01T00:45:00") => 6.666666666666666,
+                    DateTime("2024-01-01T00:50:00") => 0.0,
+                    DateTime("2024-01-01T00:55:00") => 0.2777777777777777,
+                    DateTime("2024-01-01T01:00:00") => 0.5555555555555555,
+                    DateTime("2024-01-01T01:05:00") => 0.8333333333333333,
+                    DateTime("2024-01-01T01:10:00") => 3.1111111111111107,
+                    DateTime("2024-01-01T01:15:00") => 5.388888888888888,
+                    DateTime("2024-01-01T01:20:00") => 7.666666666666666,
+                    DateTime("2024-01-01T01:25:00") => 5.666666666666666,
+                    DateTime("2024-01-01T01:30:00") => 3.666666666666666,
+                    DateTime("2024-01-01T01:35:00") => 1.6666666666666665,
+                    DateTime("2024-01-01T01:40:00") => 2.333333333333333,
+                    DateTime("2024-01-01T01:45:00") => 2.9999999999999996,
+                    DateTime("2024-01-01T01:50:00") => 3.6666666666666665,
+                    DateTime("2024-01-01T01:55:00") => 2.5555555555555554,
+                    DateTime("2024-01-01T02:00:00") => 1.4444444444444442,
+                    DateTime("2024-01-01T02:05:00") => 0.3333333333333333,
+                    DateTime("2024-01-01T02:10:00") => 4.888888888888888,
+                    DateTime("2024-01-01T02:15:00") => 7.166666666666667)
+    @test all([demand.energy_profile.data[k] - expected[k] for k in keys(expected)] .<
+              simulation_parameters["epsilon"]) == true
+    @test all([demand.energy_profile.data[k] - expected[k] for k in keys(demand.energy_profile.data)] .<
+              simulation_parameters["epsilon"]) == true
+    @test sum(values(demand.energy_profile.data)) ≈ 136.22222222222222
+
+    @test demand.temperature_profile.time_step == 300
+    @test demand.temperature_profile.data_type == :intensive
+    expected = Dict(DateTime("2024-01-01T00:00:00") => 65.0,
+                    DateTime("2024-01-01T00:05:00") => 65.0,
+                    DateTime("2024-01-01T00:10:00") => 64.33333333333333,
+                    DateTime("2024-01-01T00:15:00") => 63.666666666666664,
+                    DateTime("2024-01-01T00:20:00") => 63.0,
+                    DateTime("2024-01-01T00:25:00") => 65.33333333333333,
+                    DateTime("2024-01-01T00:30:00") => 67.66666666666666,
+                    DateTime("2024-01-01T00:35:00") => 70.0,
+                    DateTime("2024-01-01T00:40:00") => 69.33333333333333,
+                    DateTime("2024-01-01T00:45:00") => 68.66666666666666,
+                    DateTime("2024-01-01T00:50:00") => 68.0,
+                    DateTime("2024-01-01T00:55:00") => 69.33333333333333,
+                    DateTime("2024-01-01T01:00:00") => 70.66666666666666,
+                    DateTime("2024-01-01T01:05:00") => 72.0,
+                    DateTime("2024-01-01T01:10:00") => 72.0,
+                    DateTime("2024-01-01T01:15:00") => 72.0,
+                    DateTime("2024-01-01T01:20:00") => 72.0,
+                    DateTime("2024-01-01T01:25:00") => 66.66666666666666,
+                    DateTime("2024-01-01T01:30:00") => 61.33333333333333,
+                    DateTime("2024-01-01T01:35:00") => 56.0,
+                    DateTime("2024-01-01T01:40:00") => 57.66666666666666,
+                    DateTime("2024-01-01T01:45:00") => 59.33333333333333,
+                    DateTime("2024-01-01T01:50:00") => 61.0,
+                    DateTime("2024-01-01T01:55:00") => 62.666666666666664,
+                    DateTime("2024-01-01T02:00:00") => 64.33333333333333,
+                    DateTime("2024-01-01T02:05:00") => 66.0,
+                    DateTime("2024-01-01T02:10:00") => 67.33333333333333,
+                    DateTime("2024-01-01T02:15:00") => 68.0)
+    @test all([demand.temperature_profile.data[k] - expected[k] for k in keys(expected)] .<
+              simulation_parameters["epsilon"]) == true
+    @test all([demand.temperature_profile.data[k] - expected[k] for k in keys(demand.temperature_profile.data)] .<
+              simulation_parameters["epsilon"]) == true
+end
+
+@testset "profiles_linear_time_preserving" begin
+    test_profile_segmentation_half_linear_time_preserving()
+    test_profile_segmentation_third_linear_time_preserving()
 end


### PR DESCRIPTION
- add the possibility to output the weather data from EPW and dat-files to the lineplot (`io_settings: "plot_weather_data"`) and CSV output (`io_settings: "csv_output_weather"`)
- add two more interpolation methods for segmentation of data. Now the following methods are available: 
   - `"stepwise"`
   - `"linear_classic"`
   - `"linear_time_preserving"`
   - `"linear_solar_radiation"`. 
  They can be specified in the profile file header (`"interpolation_type"`) and for weather solar data (`simulation_parameters: "weather_interpolation_type_solar"`)  and other weather data (`simulation_parameters: "weather_interpolation_type_general"`) separately. 
- the time zone can now be specified in the simulation_parameters using `"time_zone"` to overwrite the time zone provided by the weather file.
- change the internal handling of profile time step during segmentation and aggregation from seconds to milliseconds
- add tests for segmentation algorithms