### PR TITLE
Fix profiles time zone dst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ In general the development follows the [semantic versioning](https://semver.org/
 ## Pre-1.0-releases
 As per the definition of semantic versioning and the reality of early development, in versions prior to 1.0.0 any release might break compatability. To alleviate this somewhat, the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some breaking changes may slip beneath notice.
 
+### Version 0.11.1
+* Fix profiles (type "datestamp") to correctly handle data with and without DST
+
 ### Version 0.11.0
 * Restructure the CLI and how simulations are performed with it.
   * Instead of a single call to the CLI script, that runs the simulation and then returns to the shell, it now puts the user into an interactive CLI that keeps prompting for commands until exited. This has the advantage that performing multiple runs without changing the code results in a significant performance boost for runs after the first one, as the code does not have be compiled again and is reused.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Resie"
 uuid = "2e0f99b1-0d8f-4296-8d0c-1c50a50d04c8"
 authors = ["Maksim Helmann <maksim.helmann@siz-energieplus.de>", "Etienne Ott <etienne.ott@siz-energieplus.de>", "Heiner Steinacker <heiner.steinacker@siz-energieplus.de>", "Adrian Vollmer <adrian.vollmer@siz-energieplus.de>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/profiles/base.jl
+++ b/src/profiles/base.jl
@@ -546,9 +546,32 @@ function remove_day_light_saving(timestamp::Vector{DateTime}, time_zone::Union{N
                    "It has to be an IANA (also known as TZ or TZDB) time zone identifier."
             throw(InputError)
         end
+        if tz isa FixedTimeZone
+            @error "The time zone $(tz) of the profile at $(file_path) is a FixedTimeZone. " *
+                   "This is not supported! Please use a VariableTimeZone given as IANA (also known as TZ or TZDB) time " *
+                   "zone identifier, or remove the time_zone parameter if you use local standard time. If you want to " *
+                   "shift the whole time series, use the parameter time_shift_seconds."
+            throw(InputError)
+        end
+
+        # check if the current time zone includes any DST within the simulation time
+        fist_time_step = nothing
+        try
+            fist_time_step = ZonedDateTime(timestamp[1], tz)
+        catch e
+            @error "In the profile at $file_path, the first datestamp $tz is probably invalid for the specified time " *
+                   "zone $time_zone. The following error occured: $e"
+            throw(InputError)
+        end
+        has_dst = false
+        next_transition = next_transition_instant(fist_time_step)
+        if next_transition !== nothing && DateTime(next_transition) > timestamp[1] &&
+           DateTime(next_transition) < timestamp[end]
+            has_dst = true
+        end
 
         timestamp_max_year = year(timestamp[end])
-        if year(tz.transitions[end].utc_datetime) < timestamp_max_year
+        if !(tz isa FixedTimeZone) && has_dst && year(tz.transitions[end].utc_datetime) < timestamp_max_year
             try
                 TimeZones.TZData.compile(; max_year=Int(timestamp_max_year))
             catch e
@@ -575,18 +598,21 @@ function remove_day_light_saving(timestamp::Vector{DateTime}, time_zone::Union{N
         has_corrected = false
         zoned_time = 0
 
-        counter = 1
+        double_timesteps = []
         for ts in timestamp
-            # Convert the timestamp to ZonedDateTime and back to DateTime to eliminate any DST effects.
-            # This results in local standard time.
             try
+                # Convert the timestamp to ZonedDateTime and back to DateTime to eliminate any DST effects.
+                # This results in local standard time.
                 possible = TimeZones.interpret(ts, tz, TimeZones.Local)
                 if length(possible) == 1
                     zoned_time = ZonedDateTime(ts, tz)
-                    counter = 1  # reset counter
                 else
-                    zoned_time = ZonedDateTime(ts, tz, counter)
-                    counter += 1 # add one to switch to the second occuurence of the duplicate hour
+                    if ts in double_timesteps
+                        zoned_time = ZonedDateTime(ts, tz, 2)
+                    else
+                        zoned_time = ZonedDateTime(ts, tz, 1)
+                    end
+                    push!(double_timesteps, ts)  # add ts to double_timesteps to track it
                 end
                 push!(corrected_timestamps, sub_ignoring_leap_days(DateTime(zoned_time), zoned_time.zone.offset.dst))
             catch e


### PR DESCRIPTION
Fix profiles using a datestamp:
- handle double time steps in ZonedDateTime with DST correctly
- explicitly deny FixedTimeZone
- fix handling of ZonedDateTime that do not include DST