### PR TITLE
Fix transformer communication with multiple potentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ In general the development follows the [semantic versioning](https://semver.org/
 ## Pre-1.0-releases
 As per the definition of semantic versioning and the reality of early development, in versions prior to 1.0.0 any release might break compatibility. To alleviate this somewhat, the meaning of major-minor-patch is "downshifted" to zero-major-minor. However some breaking changes may slip beneath notice.
 
+## Version 0.13.11
+* Changed transformer potential handling so `MaxEnergy` is no longer updated in interfaces toward (proxy) buses and is instead written only to the bus balance table, allowing `balance_on()` of the bus to correctly handle multiple transformers with multiple potential steps; linked interfaces remain an exception and still require to update `MaxEnergy` in the interfaces during potential step for correct communication.
+* Fixed `inner_distribute` in buses to avoid `Inf - Inf`, which previously produced `NaN` values in the bus balance table in some rare cases
+
 ### Version 0.13.10
 * Fix function reorder_src_snk_connected_to-transformer not working after merges of new battery model
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Resie"
 uuid = "2e0f99b1-0d8f-4296-8d0c-1c50a50d04c8"
 authors = ["Elias Demartin <elias.demartin@siz-energieplus.de>", "Maksim Helmann <maksim.helmann@siz-energieplus.de>", "Etienne Ott <etienne.ott@siz-energieplus.de>", "Heiner Steinacker <heiner.steinacker@siz-energieplus.de>", "Adrian Vollmer <adrian.vollmer@siz-energieplus.de>"]
-version = "0.13.10"
+version = "0.13.11"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/energy_systems/base.jl
+++ b/src/energy_systems/base.jl
@@ -536,8 +536,12 @@ function set_max_energy!(interface::SystemInterface,
     end
 
     if interface.source.sys_function == sf_bus
-        set_max_energy!(interface.max_energy, energy, temperature_min, temperature_max, purpose_uac,
-                        has_calculated_all_maxima, recalculate_max_energy)
+        # in process, update the interface. Keep it empty in potential to handel multiple potential steps correctly.
+        if !is_transformer_potential
+            set_max_energy!(interface.max_energy, energy, temperature_min, temperature_max, purpose_uac,
+                            has_calculated_all_maxima, recalculate_max_energy)
+        end
+        # update bus 
         set_max_energy!(interface.source,
                         interface.target,
                         false,
@@ -546,10 +550,16 @@ function set_max_energy!(interface::SystemInterface,
                         temperature_max,
                         purpose_uac,
                         has_calculated_all_maxima,
-                        recalculate_max_energy)
+                        recalculate_max_energy,
+                        false,
+                        is_transformer_potential)
     elseif interface.target.sys_function == sf_bus
-        set_max_energy!(interface.max_energy, energy, temperature_min, temperature_max, purpose_uac,
-                        has_calculated_all_maxima, recalculate_max_energy)
+        # in process, update the interface. Keep it empty in potential to handel multiple potential steps correctly.
+        if !is_transformer_potential
+            set_max_energy!(interface.max_energy, energy, temperature_min, temperature_max, purpose_uac,
+                            has_calculated_all_maxima, recalculate_max_energy)
+        end
+        # update bus 
         set_max_energy!(interface.target,
                         interface.source,
                         true,
@@ -559,7 +569,8 @@ function set_max_energy!(interface::SystemInterface,
                         purpose_uac,
                         has_calculated_all_maxima,
                         recalculate_max_energy,
-                        interface.is_secondary_interface)
+                        interface.is_secondary_interface,
+                        is_transformer_potential)
     else
         # 1-to-1 interface between two components.
         # Assuming that temperatures always match: This is valid as currently only heat pumps
@@ -800,7 +811,6 @@ function reduce_max_energy!(max_energy::EnergySystems.MaxEnergy,
                     end
                 end
             else
-                test = 1
                 @error "The uac could not be found in the max_energy."
             end
         end

--- a/src/energy_systems/connections/bus.jl
+++ b/src/energy_systems/connections/bus.jl
@@ -916,7 +916,7 @@ function inner_distribute!(unit::Bus; caller_uac_transformer_only::Stringing=not
         unit.balance_table[input_row.priority, output_row.priority * 2] = lowest(temperature_highest_min,
                                                                                  temperature_lowest_max)
 
-        if energy_flow !== 0.0
+        if energy_flow !== 0.0 && !isinf(energy_flow)
             # extract the already distributed energy from the balance table
             already_distributed_input_energies = Float64.(unit.balance_table[input_row.priority, 1:2:end])
             already_distributed_input_temperatures = unit.balance_table[input_row.priority, 2:2:end]

--- a/src/energy_systems/connections/bus.jl
+++ b/src/energy_systems/connections/bus.jl
@@ -351,7 +351,8 @@ function set_max_energy!(unit::Bus,
                          purpose_uac::Union{Stringing,Vector{<:Stringing}},
                          has_calculated_all_maxima::Bool,
                          recalculate_max_energy::Bool,
-                         is_secondary_interface::Bool=false)
+                         is_secondary_interface::Bool=false,
+                         is_transformer_potential::Bool=false)
     bus = unit.proxy === nothing ? unit : unit.proxy
     com_uac = adjust_name_if_secondary(comp.uac, is_secondary_interface)
 
@@ -373,7 +374,8 @@ function set_max_energy!(unit::Bus,
                         recalculate_max_energy)
     end
 
-    if unit.proxy !== nothing
+    # update also proxy interface, but only in process-step, not in potential
+    if unit.proxy !== nothing && !is_transformer_potential
         proxy_interface = is_input ?
                           bus.input_interfaces[bus.balance_table_inputs[com_uac].priority] :
                           bus.output_interfaces[bus.balance_table_outputs[comp.uac].priority]
@@ -601,7 +603,11 @@ function balance_on(interface::SystemInterface, unit::Bus)::Vector{EnergyExchang
                     energy_pot = 0.0
                 end
             else
-                if is_max_energy_nothing(interface.max_energy) # the caller has not calculated its potential
+                if unit.balance_table[input_row.priority, output_row.priority * 2 - 1] == 0.0 &&
+                   is_max_energy_nothing(interface.max_energy)
+                    # the caller has not calculated its potential OR has another potential AND 
+                    # no energy has been distributed in the bus balance table due to other restrictions,
+                    # so get the original energy that are required by the output, including the temperatures.
                     temperature_min = get_min_temperature(output_row.energy_potential_temp, output_row.energy_pool_temp,
                                                           input_row.source.uac)
                     temperature_max = get_max_temperature(output_row.energy_potential_temp, output_row.energy_pool_temp,
@@ -660,8 +666,11 @@ function balance_on(interface::SystemInterface, unit::Bus)::Vector{EnergyExchang
                     energy_pot = 0.0
                 end
             else
-                if is_max_energy_nothing(interface.max_energy)
-                    # no max_energy is written, but maybe temperatures --> get infos from input_row
+                if unit.balance_table[input_row.priority, output_row.priority * 2 - 1] == 0.0 &&
+                   is_max_energy_nothing(interface.max_energy)
+                    # the caller has not calculated its potential OR has another potential AND 
+                    # no energy has been distributed in the bus balance table due to other restrictions,
+                    # so get the original energy that are supplied by the input, including the temperatures
                     temperature_min = get_min_temperature(input_row.energy_potential_temp, input_row.energy_pool_temp,
                                                           output_row.target.uac)
                     temperature_max = get_max_temperature(input_row.energy_potential_temp, input_row.energy_pool_temp,

--- a/src/energy_systems/heat_producers/heat_pump.jl
+++ b/src/energy_systems/heat_producers/heat_pump.jl
@@ -475,11 +475,13 @@ function set_max_energies!(unit::HeatPump,
                     is_transformer_potential=is_transformer_potential)
     set_max_energy!(unit.output_interfaces[unit.m_heat_out], heat_out, nothing, slices_heat_out_temperature,
                     purpose_uac_heat_out, has_calculated_all_maxima_heat_out;
-                    is_transformer_potential=is_transformer_potential)
+                    is_transformer_potential=(is_transformer_potential && !unit.has_secondary_interface))
     if unit.has_secondary_interface
         set_max_energy!(unit.output_interfaces[unit.m_heat_out_secondary], heat_out_secondary, nothing,
                         slices_heat_out_secondary_temperature, purpose_uac_heat_out_secondary,
-                        has_calculated_all_maxima_heat_out; is_transformer_potential=is_transformer_potential)
+                        has_calculated_all_maxima_heat_out; is_transformer_potential=false)
+        # if unit.has_secondary_interface, always write max energy to allow communication  
+        # across the two interfaces. This may can lead to problems in very complex energy systems.
     end
 end
 


### PR DESCRIPTION
- Changed transformer potential handling so `MaxEnergy` is no longer updated in interfaces toward (proxy) buses and is instead written only to the bus balance table, allowing `balance_on()` of the bus to correctly handle multiple transformers with multiple potential steps; linked interfaces remain an exception and still require to update `MaxEnergy` in the interfaces during potential step for correct communication.
- Fixed `inner_distribute` in buses to avoid `Inf - Inf`, which previously produced `NaN` values in the bus balance table in some rare cases